### PR TITLE
Change ebib-call-file-viewer to handle file names containing spaces

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -3253,11 +3253,11 @@ which file to choose."
                              (locate-file file ebib-file-search-dirs)
                              (locate-file (file-name-nondirectory file) ebib-file-search-dirs)
                              file)))))
-		(let ((file-full-path (locate-file filename ebib-file-search-dirs)))
-			(if (not file-full-path)
-				(cond
-					(n (setq file-full-path (funcall nth-filename filename n)))
-					((file-exists-p filename) (setq file-full-path filename))))
+    (let ((file-full-path (locate-file filename ebib-file-search-dirs)))
+      (if (not file-full-path)
+        (cond
+          ((file-exists-p filename) (setq file-full-path filename))
+          (n (setq file-full-path (funcall nth-filename filename n)))))
       (if (file-exists-p file-full-path)
         (progn
           (setq file-full-path (expand-file-name file-full-path))


### PR DESCRIPTION
`ebib-call-file-viewer` chokes on file names that contain spaces because it treats the spaces as a list separator between multiple file names. While I'm no fan of spaces in file names, this is problematic because a number of other reference managers automatically generate file names based on a papers title, causing interoperability problems when using ebib. This fix works around the issue by first testing if the file path exists (spaces and all), before attempting to extract an element from a list. Perhaps a better solution in the long run is to use a semicolon as the file name separator, such as used with [multiple identical fields](http://ebib.sourceforge.net/manual/ebib-manual.html#multiple-identical-fields)

The parameters have been changed to: `(defun ebib-call-file-viewer (filename &optional n) ...`
Where _filename_ is the full path to a file (may contain spaces), or a list of filenames separated by a space (these may still not contain spaces). When passed a list of filenames, _n_ designates the list element.

```
(ebib-call-file-viewer "~/papers/Hello, World.pdf")               ;=> success
(ebib-call-file-viewer "~/papers/Hello, World.pdf" 0)             ;=> error opening "~/papers/Hello,"
(ebib-call-file-viewer "~/papers/hello.pdf ~/papers/world.pdf" 1) ;=> success opening "world.pdf"
```
