### PR TITLE
Add drag-and-drop new entry stubs for OSX.

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -2419,27 +2419,48 @@ ascending sequence."
     ((default)
      (beep))))
 
-(defun ebib-add-file-entry (&optional filepath disablepromptp db)
+(defun ebib-add-file-entry (&optional filepath allow-duplicates-p disable-prompt-p db)
   "Add an entry stub for an optional FILEPATH to DB. If FILEPATH
 is a list, add entries for each file contained within. If
 FILEPATH is a directory, add entries for all its contents. And
 if FILEPATH is not given, prompt the user to browse in the
-minibuffer. By default, if FILEPATH is not given, prompt the
-user to browse a for file to add using the minibuffer. Disable
-this behavior by setting DISABLEPROMPTP to T."
+minibuffer. If a FILEPATH is already referenced by an entry in
+the DB, then it is ignored by default. If ALLOW-DUPLICATES-P is
+true, then add new entry stubs for each file anyway. By default,
+if FILEPATH is not given, prompt the user to browse a for file
+to add using the minibuffer. Disable this behavior by setting
+DISABLE-PROMPT-P to T."
   (interactive)
-  (if (and (null filepath) (null disablepromptp))
-    (setq filepath (read-file-name "Add file or directory: " (car ebib-file-search-dirs))))
-  (cond
-    ((listp filepath)
-      (dolist (fp filepath) (ebib-add-file-entry fp t db)))
-    ((file-directory-p filepath)
-      (ebib-add-file-entry (directory-files filepath t "^\\([^.]\\)") t db)) ;ignore hidden files
-    ((file-exists-p filepath)
-      (ebib-add-entry-stub (list (cons ebib-standard-file-field filepath)) db)
-      (ebib-fill-entry-buffer))
-    (t
-      (error "Invalid file %s" filepath))))
+  (let* ((all-entry-files (list))
+         (file-exists-in-db-p '(lambda (fp)
+                                 (if (member (locate-file fp ebib-file-search-dirs) all-entry-files)
+                                   t)))
+         (add-file-entry '(lambda (fp)
+                            (cond
+                              ((listp fp)
+                                (dolist (file fp) (funcall add-file-entry file)))
+                              ((file-directory-p fp)
+                                (funcall add-file-entry (directory-files fp t "^\\([^.]\\)"))) ;ignore hidden
+                              ((file-exists-p fp)
+                                (if (and (null allow-duplicates-p) (funcall file-exists-in-db-p fp))
+                                  (message "File %s already exists in db, skipping" fp)
+                                  (progn
+                                    (ebib-add-entry-stub (list (cons ebib-standard-file-field fp)) db)
+                                    (ebib-fill-entry-buffer)
+                                    (message "Adding file %s" fp))))
+                              (t
+                                (error "Invalid file %s" fp))))))
+    ;;prompt for file
+    (if (and (null filepath) (null disable-prompt-p))
+      (setq filepath (read-file-name "Add file or directory: " (car ebib-file-search-dirs))))
+    ;;collect all file paths from db entries into single list
+    (unless allow-duplicates-p
+      (dolist (entry-key (edb-keys-list (or db ebib-cur-db)))
+        (let ((entry-files (to-raw (car (ebib-get-field-value ebib-standard-file-field entry-key)))))
+          (if entry-files
+            (dolist (fp (split-string entry-files ebib-filename-separator))
+              (add-to-list 'all-entry-files (locate-file fp ebib-file-search-dirs)))))))
+    (funcall add-file-entry filepath)))
 
 (defun ebib-uniquify-key (key)
   "Creates a unique key from KEY."


### PR DESCRIPTION
Although this pull request still needs to be refactored against `ebib-add-entry` with some error checks/alternatives for other os/window systems, it should give you an idea what I'm thinking.

It allows you to drag-and-drop a file, or directory of files (which may contain directories of files, etc.) and add them as temporary entries. The file paths are added to the `ebib-standard-file-field` via `ebib-file-relative-name`, so it uses the relative name first, then the full file path if not found in the search directories. Temp entry keys are: `<new-entry>, <new-entry-1>, <new-entry-2>`, etc.

This is more of a workflow enhancement than anything else. Typically I browse, read, download, and organize papers before filling in the actual bibtex info (but this is of course a personal preference). It's been nice to use ebib in the organizational stages.

Perhaps down the road, in my own `.emacs`, I can add convenience functions that automatically copy files from my downloads folder into my `ebib-file-search-dirs` when I drag them over to ebib.

The drag-and-drop binds to [ns-drag-file](https://www.gnu.org/software/emacs/manual/html_node/emacs/Mac-_002f-GNUstep-Events.html), I've only tested on OSX, so I'm unsure how it affects Linux or Windows.
