### PR TITLE
Add %U & %L to ebib-notes-template

### DIFF
--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -146,6 +146,42 @@ the entry for which a URL is to be created."
 (defun ebib-notes-create-org-url (key)
   (ebib-db-get-field-value "url" key ebib--cur-db 'noerror 'unbraced 'xref))
 
+(defcustom ebib-notes-label-function 'ebib-notes-create-org-label
+  "Function to create a LABEL for a notes entry.
+This function is used to fill the %L directive in
+`ebib-notes-template'.  It should take one argument, the key of
+the entry for which a LABEL is to be created.
+By default, the label for KEY is read from
+a .bbl file in the directory where the current
+bibtex db resides."
+  :group 'ebib-notes
+  :type 'function)
+
+(defun ebib-notes-create-org-label (key)
+  "Return bibtex LABEL for an orgmode note for KEY."
+  (let* ((bbl-dir (file-name-directory (ebib-db-get-filename ebib--cur-db)))
+	 (bbl-files (directory-files bbl-dir nil ".*[.]bbl"))
+	 (bbl-file (car bbl-files)))
+    (message "cmj: found bbl dir '%s'" bbl-dir)
+    (message "cmj: found bbl files %s" bbl-files)
+    (message "cmj: found bbl file '%s'" bbl-file)
+    (cond
+     ((= 0 (length bbl-files))
+      (error "no .bbl file found in '%s' dir; maybe run bibtex?" bbld-ir))
+     ((= 1 (length bbl-files))
+      ; all's well
+      t)
+     (t (error "too many .bbl files, can't determine which of %s to use" bbl-files)))
+    (with-temp-buffer
+      (insert-file-contents (concat bbl-dir bbl-file))
+      (or (re-search-forward (format "\\entry{%s}" key) nil t)
+	  (error "can't find entry [%s] in '%s'" key bbl-file))
+      (or (re-search-forward (format "\\field{labelalpha}{\\([^}]*\\)}") nil t)
+	  (error "can't find label for bib entry [%s]; rerun bibtex? or rerurn latex, then bibtex?" key))
+      (let ((label (match-string 1)))
+	(message "cmj: label for key [%s] is '%s'" key label)
+	label))))
+
 (defcustom ebib-notes-identifier-function 'ebib-notes-create-org-identifier
   "Function to create the identifier of a note.
 This function should take the key of the entry as argument and
@@ -193,7 +229,8 @@ string where point should be located."
   (let* ((note (format-spec ebib-notes-template
                             `((?K . ,(funcall ebib-notes-identifier-function key))
                               (?T . ,(funcall ebib-notes-title-function key))
-			       (?U . ,(funcall ebib-notes-url-function key)))))
+			      (?U . ,(funcall ebib-notes-url-function key))
+			      (?L . ,(funcall ebib-notes-label-function key)))))
          (point (string-match-p ">|<" note)))
     (if point
         (setq note (replace-regexp-in-string ">|<" "" note))

--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -135,6 +135,17 @@ string."
                    "(No Title)")))
     (replace-regexp-in-string "\n" "" (format "%s (%s): %s" author year title))))
 
+(defcustom ebib-notes-url-function 'ebib-notes-create-org-url
+  "Function to create a URL for a notes entry.
+This function is used to fill the %U directive in
+`ebib-notes-template'.  It should take one argument, the key of
+the entry for which a URL is to be created."
+  :group 'ebib-notes
+  :type 'function)
+
+(defun ebib-notes-create-org-url (key)
+  (ebib-db-get-field-value "url" key ebib--cur-db 'noerror 'unbraced 'xref))
+
 (defcustom ebib-notes-identifier-function 'ebib-notes-create-org-identifier
   "Function to create the identifier of a note.
 This function should take the key of the entry as argument and
@@ -181,7 +192,8 @@ Return a cons of the new note as a string and a position in this
 string where point should be located."
   (let* ((note (format-spec ebib-notes-template
                             `((?K . ,(funcall ebib-notes-identifier-function key))
-                              (?T . ,(funcall ebib-notes-title-function key)))))
+                              (?T . ,(funcall ebib-notes-title-function key))
+			       (?U . ,(funcall ebib-notes-url-function key)))))
          (point (string-match-p ">|<" note)))
     (if point
         (setq note (replace-regexp-in-string ">|<" "" note))


### PR DESCRIPTION
I've added `%U` and `%L` to the ebib notes template.  As you might guess, it pulls in the URL of a bib entry.

`%L` is maybe more controversial.  When I'm making a single notes file, I want to see the reference label bibtex/biblatex would give for the entry.  So, the `%L` support  goes hunting up a `.bbl` file, looks up the `\field{labelalpha}` directive for the relevant key, and replaces `%L` with what it parses.  It's all done via regexes, so that's a tad sketchy.

Worse, I'm using `bib latex`, not `bibtex`.  My guess is that `bibtex` produces `bibitem` entries in a `.bbl` file.  For the %L support to be a bit more general, I supposed I'd need to look for `bibitem`, too.

Also, the way the `.bbl` file is found is...not the nicest, as you'll see.

Still, I created the pull request so you could get the idea of what I'm trying to do.  Let me know what you think.  I may get some time to spruce up the `%L` support if you think that's worth doing.  It'll be a few weeks before I could have a go at that, though.
