### PR TITLE
Enhance the display of the index buffer

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -255,6 +255,11 @@ not change the default sort."
                         (integer :tag "Width")
                         (boolean :tag "Sort"))))
 
+(defcustom ebib-index-column-separator "  "
+  "Separator between columns in the index buffer."
+  :group 'ebib
+  :type 'string)
+
 (defcustom ebib-uniquify-keys nil
   "Create unique keys.
 When adding new entries to the database, Ebib does not allow

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1259,6 +1259,17 @@ transformed by the associated function."
   (let ((str (ebib-db-get-field-value field key db "" 'unbraced 'xref)))
     (replace-regexp-in-string "[{}]" "" str)))
 
+(defun ebib-display-journal-initials (field key db)
+  (let ((str (ebib-db-get-field-value field key db "" 'unbraced 'xref)))
+    (if (string-match-p "\s+" str)
+        (apply 'concat
+               (mapcar
+                (lambda (str) (substring str 0 1))
+                (seq-difference
+                 (mapcar 'capitalize (split-string str "\\Sw+" t))
+                 '("A" "An" "At" "Of" "On" "And" "For"))))
+      str)))
+
 (defun ebib-display-note-symbol (_field key _db)
   "Return the note symbol for displaying if there exists a note."
   (if (ebib--notes-exists-note key)

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -265,11 +265,11 @@ not change the default sort."
                                                 ("Url" . ebib-display-www-link)
                                                 ("Note" . ebib-display-note-symbol))
   "Functions transforming field contents to appropriate forms.
-Each function accepts three arguments (see
+Each function accepts three arguments (same with the arguments of
 `ebib--get-field-value-for-display') and returns a string to be
 displayed in the ebib index buffer."
   :group 'ebib
-  :type '(repeat (list (string :tag "Field")
+  :type '(repeat (cons (string :tag "Field")
                        (function :tag "Transform function"))))
 
 (defcustom ebib-uniquify-keys nil

--- a/ebib.el
+++ b/ebib.el
@@ -728,6 +728,7 @@ KEY.  In this case, COMMAND is meaningless."
     (define-key map "Y" #'ebib-keywords-add) ; prefix
     (define-key map "z" #'ebib-leave-ebib-windows)
     (define-key map "Z" #'ebib-lower)
+    (define-key map [mouse-1] #'ebib-open-at-point)
     map)
   "Keymap for the ebib index buffer.")
 
@@ -2192,6 +2193,22 @@ Operates either on all entries or on the marked entries."
        (ebib-db-set-current-entry-key (ebib--get-key-at-point) ebib--cur-db)
        (setq ebib--cur-db new-db)
        (ebib--update-buffers)))))
+
+(defun ebib-index-open-at-point ()
+  "Open link, note or files at point."
+  (interactive)
+  (let* ((word (thing-at-point 'word))
+         (link (and (get-text-property 0 'mouse-face word)
+                    (get-text-property 0 'help-echo word)))
+         (notep (and (get-text-property 0 'mouse-face word)
+                     (string-equal word ebib-notes-symbol))))
+    (cond
+     (link
+      (ebib--call-browser link))
+     (notep
+      (ebib-open-note))
+     (t
+      (ebib-select-and-popup-entry)))))
 
 (defun ebib-browse-url (arg)
   "Browse the URL in the standard URL field.

--- a/ebib.el
+++ b/ebib.el
@@ -137,7 +137,9 @@ is applied to the item."
       (while (< n max)
         (let ((width (cadr (nth n ebib-index-columns)))
               (item (nth n (cadr data))))
-          (insert (format (concat "%-" (int-to-string width) "s") (truncate-string-to-width item width nil nil t)) "  "))
+          (insert (format
+                   (concat "%-" (int-to-string width) "s") (truncate-string-to-width item width nil nil t))
+                  ebib-index-column-separator))
         (cl-incf n))
       ;; The last item isn't truncated
       (insert (nth n (cadr data)))

--- a/ebib.el
+++ b/ebib.el
@@ -728,7 +728,7 @@ KEY.  In this case, COMMAND is meaningless."
     (define-key map "Y" #'ebib-keywords-add) ; prefix
     (define-key map "z" #'ebib-leave-ebib-windows)
     (define-key map "Z" #'ebib-lower)
-    (define-key map [mouse-1] #'ebib-open-at-point)
+    (define-key map [mouse-1] #'ebib-index-open-at-point)
     map)
   "Keymap for the ebib index buffer.")
 
@@ -2198,9 +2198,11 @@ Operates either on all entries or on the marked entries."
   "Open link, note or files at point."
   (interactive)
   (let* ((word (thing-at-point 'word))
-         (link (and (get-text-property 0 'mouse-face word)
+         (link (and word
+                    (get-text-property 0 'mouse-face word)
                     (get-text-property 0 'help-echo word)))
-         (notep (and (get-text-property 0 'mouse-face word)
+         (notep (and word
+                     (get-text-property 0 'mouse-face word)
                      (string-equal word ebib-notes-symbol))))
     (cond
      (link


### PR DESCRIPTION
Because it often doesn't look well to display the original field content, this pull request enables customizable display of fields in the index buffer, such as

- remove the latex markups, mainly '{}', in the title field
- abbreviate long author/journal fields
- use symbols to indicate the url/doi/file/notes/group/...

In addition, I would like that the columns shown in the index buffer is independent of bibtex or biblatex fields, i.e., a column, which has its own name, can be associated to one field, multiple fields, or other information (e.g. note/group/...). For example, a 3-character wide column named "www" can be defined as `("Doi" "Url") 3)`, which displays the information provided by the Doi field, or the Url field if the Doi field is empty. I would like to know your opinions, thanks.