### PR TITLE
Allow command-line options in ebib-file-associations.

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -474,8 +474,10 @@ this command extracts the filename."
                                 ("ps" . "gv"))
   "List of file associations.
 Lists file extensions together with external programs to handle
-files with those extensions.  The program is searched for in
-`exec-path'.
+files with those extensions. If the program string contains a
+literal `%s', it is replaced with the name of the file being
+opened, allowing the use of command-line options. Otherwise, the
+string is treated as an executable, searched for in `exec-path'.
 
 When you open a file for which no external program is defined,
 the file is opened in Emacs."

--- a/ebib.el
+++ b/ebib.el
@@ -2252,7 +2252,10 @@ argument ARG can be used to specify which file to choose."
           (ebib--ifstring (viewer (cdr (assoc ext ebib-file-associations)))
               (progn
                 (message "Executing `%s %s'" viewer file-full-path)
-                (start-process (concat "ebib " ext " viewer process") nil viewer file-full-path))
+                (if (string-match (regexp-quote "%s") viewer)
+                    (let* ((viewer-arg-list (split-string-and-unquote (format viewer file-full-path))))
+                      (apply 'start-process (concat "ebib " ext " viewer process") nil viewer-arg-list))
+                  (start-process (concat "ebib " ext " viewer process") nil viewer file-full-path)))
             (message "Opening `%s'" file-full-path)
             (ebib-lower)
             (find-file file-full-path)))


### PR DESCRIPTION
Previously, the viewer name in ebib-file-associations needed to be
precisely an executable to be found on exec-path. Now it can also
contain command-line options, and a "%s" where the file path needs to
go.

If the string contains no "%s", it falls-back to the original behavior,
and is therefore backwards compatible.