### PR TITLE
Bug fix: use ebib--keywords-history instead of ebib-keyword-history

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -2539,7 +2539,7 @@ uses standard Emacs completion."
 Return the keywords entered as a list.  Any keywords not in
 COLLECTION are added to the current database's keywords list.  If
 no keywords are entered, the return value is nil."
-  (let ((keywords (cl-loop for keyword = (completing-read (format "Add keyword (ENTER to finish) [%s]: " (mapconcat #'identity keywords " ")) collection nil nil nil 'ebib-keyword-history)
+  (let ((keywords (cl-loop for keyword = (completing-read (format "Add keyword (ENTER to finish) [%s]: " (mapconcat #'identity keywords " ")) collection nil nil nil 'ebib--keywords-history)
                            until (string= keyword "")
                            collecting keyword into keywords
                            finally return keywords)))


### PR DESCRIPTION
The defvar defines ebib--keywords-history but that is never used.  Seems to have been overlooked when renaming variables back in 2014/2015.