### PR TITLE
Add ACL anthology download transformation.

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -703,7 +703,7 @@ possible to use the same separator in the `url' field as in the
 (defcustom ebib-url-download-transformations '(("https?://arxiv.org/abs/" . ebib-transform-arXiv-url)
                                                ("https?://ling.auf.net/lingBuzz/" . ebib-transform-lingbuzz-url)
                                                ("https?://www.jstor.org/" . ebib-transform-jstor-url)
-                                               ("https?://(www.)?aclweb.org/anthology/" . ebib-transform-aclanthology-url)
+                                               ("https?://\\(www.\\)?aclweb.org/anthology/" . ebib-transform-aclanthology-url)
                                                ("https?://link.aps.org/" . ebib-transform-aps-url))
   "Transformations to apply to a URL before attempting to download a pdf file.
 Each entry consists of a matcher and a transformation function.

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -703,6 +703,7 @@ possible to use the same separator in the `url' field as in the
 (defcustom ebib-url-download-transformations '(("https?://arxiv.org/abs/" . ebib-transform-arXiv-url)
                                                ("https?://ling.auf.net/lingBuzz/" . ebib-transform-lingbuzz-url)
                                                ("https?://www.jstor.org/" . ebib-transform-jstor-url)
+                                               ("https?://(www.)?aclweb.org/anthology/" . ebib-transform-aclanthology-url)
                                                ("https?://link.aps.org/" . ebib-transform-aps-url))
   "Transformations to apply to a URL before attempting to download a pdf file.
 Each entry consists of a matcher and a transformation function.
@@ -759,6 +760,12 @@ transformation function is applied to the URL."
       (replace-regexp-in-string (regexp-quote "/link.aps.org/doi/") "/journals.aps.org/rmp/pdf/" url t t))
      ((string-match (regexp-quote "PhysRevPhysEducRes") url)
       (replace-regexp-in-string (regexp-quote "/link.aps.org/doi/") "/journals.aps.org/prper/pdf/" url t t)))))
+
+(defun ebib-transform-aclanthology-url (url)
+  "Transform an ACL anthology URL to the URL of its correspnoding pdf file."
+  (if (string-match-p "\\.pdf$" url)
+	  url
+	(concat (string-remove-suffix "/" url) ".pdf")))
 
 (defcustom ebib-browser-command nil
   "Command to call the browser with.


### PR DESCRIPTION
The canonical URL is "https://www.aclweb.org/anthology/ID",
the PDF URL is "https://www.aclweb.org/anthology/ID.pdf".
Also remove potentially superfluous slash at the end as "ID/" is also
a valid URL and might have slipped in for some users.