### PR TITLE
Show format string to user when prompting for arguments

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -401,6 +401,12 @@ a description as used in Org-mode links.  The user is prompted
 for this description, but if possible a default is provided,
 which can be accepted by hitting RET.
 
+If
+`ebib-citation-show-format-string-when-prompting-for-arguments`
+is set, the entire format string is included in the prompt for
+arguments for the citation command so that the user can see what
+the arguments will be used for.  It defaults to nil.
+
 Optional material around %A is only included if the user provides
 some string for %A.  If not, the optional material is omitted.
 
@@ -420,6 +426,15 @@ provided, the user is prompted to supply one."
                        (repeat (list :tag "Citation command"
                                      (string :tag "Identifier")
                                      (string :tag "Format string"))))))
+
+(defcustom ebib-citation-show-format-string-when-prompting-for-arguments nil
+  "Whether to display the format string template when prompting for arguments.
+If the format string template includes arguments to prompt from
+the user, ie. contains %A, then show the full format string
+template to the user so that they can see how the arguments will
+be used."
+  :group 'ebib
+  :type 'boolean)
 
 (defcustom ebib-citation-description-function 'ebib-author-year-description
   "Function for creating a description to be used in citations.

--- a/ebib.el
+++ b/ebib.el
@@ -2787,9 +2787,10 @@ data for entry KEY in DB."
                   (arg-prompt (if (string= arg-type "%D") "Description" "Argument"))
                   (default (when (and key db (string= arg-type "%D"))
                              (funcall ebib-citation-description-function key db)))
-                  (prompt (format "%s%s%s%s: "
+                  (prompt (format "%s%s%s%s%s: "
                                   arg-prompt
                                   (if (string= arg-prompt "Argument") (format " %s" n) "")
+                                  (concat " in «" format-string "»")
                                   (if key (concat " for " key) "")
                                   (if default (concat " (default: «" default "»)") "")))
                   (replacement (ebib--ifstring (argument (read-string prompt nil nil default))

--- a/ebib.el
+++ b/ebib.el
@@ -2770,6 +2770,11 @@ optional material both before and after %A.  If the user supplies
 an empty string for such an argument, the optional material
 surrounding it is not included in the citation command.
 
+If variable
+`ebib-citation-show-format-string-when-prompting-for-arguments`
+is set, the entire FORMAT-STRING will be displayed in the prompt
+for user to see.
+
 FORMAT-STRING may also contain a %D directive.  This is replaced
 with a description, for which the user is prompted, although a
 default value is provided, which the user can accept by hitting
@@ -2790,7 +2795,7 @@ data for entry KEY in DB."
                   (prompt (format "%s%s%s%s%s: "
                                   arg-prompt
                                   (if (string= arg-prompt "Argument") (format " %s" n) "")
-                                  (concat " in «" format-string "»")
+                                  (if ebib-citation-show-format-string-when-prompting-for-arguments (concat " in «" format-string "»") "")
                                   (if key (concat " for " key) "")
                                   (if default (concat " (default: «" default "»)") "")))
                   (replacement (ebib--ifstring (argument (read-string prompt nil nil default))

--- a/manual/ebib.text
+++ b/manual/ebib.text
@@ -521,7 +521,7 @@ In order to be able to insert such citations, the format string must contain `%A
 ```
 {{endraw}}
 
-With such a format string, Ebib asks the user to provide text for the two arguments and inserts it at the locations specified by the directives. Of course, it is possible to leave the arguments empty (by just hitting `RET`). With the format string above, this would yield the following citation in the LaTeX buffer:
+With such a format string, Ebib asks the user to provide text for the two arguments and inserts it at the locations specified by the directives. If `ebib-citation-show-format-string-when-prompting-for-arguments` is set, the format string is included in it's entirety in the prompt. Of course, it is possible to leave the arguments empty (by just hitting `RET`). With the format string above, this would yield the following citation in the LaTeX buffer:
 
     \textcite[][]{Jones1992}
 
@@ -588,6 +588,8 @@ Of course it is also possible to combine parts that are repeated with parts that
 {{endraw}}
 
 Multicite commands in `biblatex` take two additional arguments surrounded with parentheses. These are pre- and postnotes for the entire sequence of citations. They can be accommodated as shown.
+
+If `ebib-citation-show-format-string-when-prompting-for-arguments` is set the format string is displayed when prompting the user for arguments for a citation (with the `%A` directive), so that they can see what the argument will be used for.
 
 Lastly, a citation command can also contain a `%D` directive. This is mainly for use in Org citations, which take the form `[[ebib:<key>][<description>]]`. The description is not an argument to the citation command but the string that will be displayed in the Org buffer.
 

--- a/test/ebib-test.el
+++ b/test/ebib-test.el
@@ -51,11 +51,16 @@
 
 (ert-deftest ebib-citation-with-a-key-and-arguments-should-accept-spaces-in-args ()
   (let ((unread-command-events (listify-key-sequence (kbd "liz SPC ard RET sna SPC ke RET"))))
-    (should (ert--explain-equal-rec (ebib--process-citation-template "%A%k%A" "key")
-                     "liz ardkeysna ke"))))
+    (should (equal(ebib--process-citation-template "%A%k%A" "key")
+                  "liz ardkeysna ke"))))
+
+
+;; TODO: Add tests for
+;; `ebib-citation-show-format-string-when-prompting-for-arguments`
+;; which is what this branch is about anyway.
 
 ;; TODO: A bit of integration testing here would be nice, say to grab some
-;; of the defined templates from the format and pushing a bit more
+;; of the defined templates from e.g. MarkDown format and pushing a bit more
 ;; realistic arguments through them, e.g. "c.f." and "pp. 22-25".
 
 ;;; ebib-test.el ends here

--- a/test/ebib-test.el
+++ b/test/ebib-test.el
@@ -9,49 +9,49 @@
 
 ;; Test the citation template processing logic.
 (ert-deftest ebib-citation-with-empty-template-should-come-through ()
-  (should (string= (ebib--process-citation-template "" "key")
+  (should (equal (ebib--process-citation-template "" "key")
                    "")))
 
 (ert-deftest ebib-citation-with-no-directives-in-template-should-come-through ()
-  (should (string= (ebib--process-citation-template "nodirectiveshere" "key")
+  (should (equal (ebib--process-citation-template "nodirectiveshere" "key")
                    "nodirectiveshere")))
 
 (ert-deftest ebib-citation-with-key-directive-should-catch-the-key ()
-  (should (string= (ebib--process-citation-template "%K" "key")
+  (should (equal (ebib--process-citation-template "%K" "key")
                    "key")))
 
 (ert-deftest ebib-citation-with-key-directive-and-surrounding-material-should-get-key-with-the-surrounded-material ()
-  (should (string= (ebib--process-citation-template "before%Kafter" "key")
+  (should (equal (ebib--process-citation-template "before%Kafter" "key")
                    "beforekeyafter")))
 
 (ert-deftest ebib-citation-with-argument-directive-should-prompt-the-user ()
   (let ((unread-command-events (listify-key-sequence (kbd "lizard RET"))))
-    (should (string= (ebib--process-citation-template "%A" "key")
+    (should (equal (ebib--process-citation-template "%A" "key")
                      "lizard"))))
 
 (ert-deftest ebib-citation-with-argument-directive-should-accept-spaces-in-args ()
   (let ((unread-command-events (listify-key-sequence (kbd "lizard SPC snake RET"))))
-    (should (string= (ebib--process-citation-template "%A" "key")
+    (should (equal (ebib--process-citation-template "%A" "key")
                      "lizard snake"))))
 
 (ert-deftest ebib-citation-with-key-and-argument-directives-should-prompt-the-user ()
   (let ((unread-command-events (listify-key-sequence (kbd "lizard RET"))))
-    (should (string= (ebib--process-citation-template "%k %A" "key")
+    (should (equal (ebib--process-citation-template "%k %A" "key")
                      "key lizard"))))
 
 (ert-deftest ebib-citation-with-argument-and-key-directives-should-prompt-the-user ()
   (let ((unread-command-events (listify-key-sequence (kbd "lizard RET"))))
-    (should (string= (ebib--process-citation-template "%A%k" "key")
+    (should (equal (ebib--process-citation-template "%A%k" "key")
                      "lizardkey"))))
 
 (ert-deftest ebib-citation-with-argument-and-key-and-argument-directives-should-prompt-the-user ()
   (let ((unread-command-events (listify-key-sequence (kbd "lizard RET snake RET"))))
-    (should (string= (ebib--process-citation-template "%A%k%A" "key")
+    (should (equal (ebib--process-citation-template "%A%k%A" "key")
                      "lizardkeysnake"))))
 
 (ert-deftest ebib-citation-with-a-key-and-arguments-should-accept-spaces-in-args ()
   (let ((unread-command-events (listify-key-sequence (kbd "liz SPC ard RET sna SPC ke RET"))))
-    (should (string= (ebib--process-citation-template "%A%k%A" "key")
+    (should (ert--explain-equal-rec (ebib--process-citation-template "%A%k%A" "key")
                      "liz ardkeysna ke"))))
 
 ;; TODO: A bit of integration testing here would be nice, say to grab some

--- a/test/ebib-test.el
+++ b/test/ebib-test.el
@@ -1,0 +1,61 @@
+;;; ebib-test.el --- Tests for ebib.el
+
+;;; Commentary:
+;; Tests for the ebib package.
+
+;;; Code:
+
+(require 'ebib)
+
+;; Test the citation template processing logic.
+(ert-deftest ebib-citation-with-empty-template-should-come-through ()
+  (should (string= (ebib--process-citation-template "" "key")
+                   "")))
+
+(ert-deftest ebib-citation-with-no-directives-in-template-should-come-through ()
+  (should (string= (ebib--process-citation-template "nodirectiveshere" "key")
+                   "nodirectiveshere")))
+
+(ert-deftest ebib-citation-with-key-directive-should-catch-the-key ()
+  (should (string= (ebib--process-citation-template "%K" "key")
+                   "key")))
+
+(ert-deftest ebib-citation-with-key-directive-and-surrounding-material-should-get-key-with-the-surrounded-material ()
+  (should (string= (ebib--process-citation-template "before%Kafter" "key")
+                   "beforekeyafter")))
+
+(ert-deftest ebib-citation-with-argument-directive-should-prompt-the-user ()
+  (let ((unread-command-events (listify-key-sequence (kbd "lizard RET"))))
+    (should (string= (ebib--process-citation-template "%A" "key")
+                     "lizard"))))
+
+(ert-deftest ebib-citation-with-argument-directive-should-accept-spaces-in-args ()
+  (let ((unread-command-events (listify-key-sequence (kbd "lizard SPC snake RET"))))
+    (should (string= (ebib--process-citation-template "%A" "key")
+                     "lizard snake"))))
+
+(ert-deftest ebib-citation-with-key-and-argument-directives-should-prompt-the-user ()
+  (let ((unread-command-events (listify-key-sequence (kbd "lizard RET"))))
+    (should (string= (ebib--process-citation-template "%k %A" "key")
+                     "key lizard"))))
+
+(ert-deftest ebib-citation-with-argument-and-key-directives-should-prompt-the-user ()
+  (let ((unread-command-events (listify-key-sequence (kbd "lizard RET"))))
+    (should (string= (ebib--process-citation-template "%A%k" "key")
+                     "lizardkey"))))
+
+(ert-deftest ebib-citation-with-argument-and-key-and-argument-directives-should-prompt-the-user ()
+  (let ((unread-command-events (listify-key-sequence (kbd "lizard RET snake RET"))))
+    (should (string= (ebib--process-citation-template "%A%k%A" "key")
+                     "lizardkeysnake"))))
+
+(ert-deftest ebib-citation-with-a-key-and-arguments-should-accept-spaces-in-args ()
+  (let ((unread-command-events (listify-key-sequence (kbd "liz SPC ard RET sna SPC ke RET"))))
+    (should (string= (ebib--process-citation-template "%A%k%A" "key")
+                     "liz ardkeysna ke"))))
+
+;; TODO: A bit of integration testing here would be nice, say to grab some
+;; of the defined templates from the format and pushing a bit more
+;; realistic arguments through them, e.g. "c.f." and "pp. 22-25".
+
+;;; ebib-test.el ends here


### PR DESCRIPTION
Hi, I implemented #144.

Without this little feature

![Screenshot 2020-01-03 at 23 03 37](https://user-images.githubusercontent.com/879300/71752023-d2c2e880-2e7d-11ea-9c36-c24791a7bd05.png)

And now with this feature enabled (defaults to disabled) the user gets is told how the arguments will be used

![Screenshot 2020-01-03 at 23 06 30](https://user-images.githubusercontent.com/879300/71752008-c9d21700-2e7d-11ea-83e1-b12a921c2e91.png)
