### PR TITLE
Prevent indefinite loop in ebib-entry-open-at-point.

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -3856,7 +3856,7 @@ viewed."
     (beginning-of-line)
     (if (eobp)
         (forward-line -1)
-      (while (ebib--outside-field-p)
+      (while (and (not (eobp)) (ebib--outside-field-p))
         (forward-line 1)))))
 
 (defun ebib-copy-field-contents ()


### PR DESCRIPTION
If the last line is empty (which is often the case with "external note" fields, `(ebib--outside-field-p)` would be returning `t` forever, and `(forward-line 1)` never fails, just returns `0`.
