### PR TITLE
Fixed ebib-add-keywords-to-entry

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -3332,7 +3332,7 @@ the current entry."
                                                       (ebib--keywords-sort new-conts)
                                                     new-conts)
                                                   entry-key ebib--cur-db 'overwrite)
-                            (mapc #'ebib--maybe-add-keywords-to-canonical-list keywords))))
+                            (ebib--maybe-add-keywords-to-canonical-list keywords))))
     (let* ((minibuffer-local-completion-map (make-composed-keymap '(keymap (32)) minibuffer-local-completion-map))
            (keywords (ebib--completing-read-keywords ebib--keywords-completion-list)))
       (when keywords


### PR DESCRIPTION
The function ebib-add-keywords-to-entry called ebib--maybe-add-keywords-to-canonical-list with strings, instead of with a list of strings. This means that 'K a' fails with an error and keywords can only be added by editing the keyword field.