### PR TITLE
Split author/editor names in a case-insensitive fashion

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -3920,7 +3920,7 @@ If FILE is not in (a subdirectory of) one of the directories in
                                                                (split-string (ebib-unbrace (or (cdr (assoc-string "author" entry 'case-fold))
                                                                                                (cdr (assoc-string "editor" entry 'case-fold))
                                                                                                ""))
-                                                                             (regexp-quote " and ") t))
+                                                                             "[[:space:]]+\\(and\\|AND\\)[[:space:]]+" t))
                                                              (apply #'seq-concatenate 'list (mapcar (lambda (db)
                                                                                                       (hash-table-values (ebib-db-val 'entries db)))
                                                                                                     (seq-filter (lambda (db)


### PR DESCRIPTION
There are many bibtex entries that sport both 'and' and 'AND' as name separator. Moreover, many of them also split over various lines or have extra spaces to have a more visually appealing format. Consider this in ebib--create-author/editor-collection when splitting the author names.