### PR TITLE
Ignore spaces when splitting keywords to list

### DIFF
--- a/ebib-keywords.el
+++ b/ebib-keywords.el
@@ -94,7 +94,8 @@ Also automatically remove duplicates."
   "Convert STR to a list of keywords.
 STR should be a string containing keywords separated by
 `ebib-keywords-separator'."
-  (split-string str (regexp-quote ebib-keywords-separator) t "[[:space:]]*"))
+  (split-string str (regexp-quote (string-trim ebib-keywords-separator))
+				t "[[:space:]]*"))
 
 (defun ebib--keywords-sort (keywords)
   "Sort the KEYWORDS string, remove duplicates, and return it as a string.


### PR DESCRIPTION
Sometimes imported entries contain keywords separated by pure commas, such as in "key1,key2". When the value of ebib-keywords-separator is ", ", the keys are not properly split. This behavior is inconsistent with the use of "[[:space:]]*" to trim the split list.