### PR TITLE
Fix multiline spaces

### DIFF
--- a/ebib-keywords.el
+++ b/ebib-keywords.el
@@ -94,7 +94,8 @@ Also automatically remove duplicates."
   "Convert STR to a list of keywords.
 STR should be a string containing keywords separated by
 `ebib-keywords-separator'."
-  (split-string str (regexp-quote ebib-keywords-separator) t "[[:space:]]*"))
+  (split-string str (regexp-quote (string-trim ebib-keywords-separator))
+				t "[[:space:]]*"))
 
 (defun ebib--keywords-sort (keywords)
   "Sort the KEYWORDS string, remove duplicates, and return it as a string.

--- a/ebib.el
+++ b/ebib.el
@@ -239,7 +239,7 @@ MULTILINES corresponds to a line in the resulting string, and all
 lines except the first one are prepended with 19 spaces."
   (let ((first-line (car multilines))
         (rest-lines (mapcar (lambda (line)
-                              (concat (make-string 19 ?\s) line))
+                              (concat (make-string 19 ?\s) (string-trim-left line)))
                             (cdr multilines))))
     (concat first-line
             (if rest-lines


### PR DESCRIPTION
When bibtex entries are created, some fields have multiple lines that are indented for readability in the *.bib files. Unfortunately, those spaces, which appear only on the 2nd and later lines, get inserted into the database. This patch eliminates those leading spaces before adding the 19 spaces that are used for displaying multiline fields, making the indentation right.