### PR TITLE
Ivy actions

### DIFF
--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -45,7 +45,8 @@
  '(("c" ebib-copy-field-contents "copy field contents")
    ("k" ebib-kill-field-contents "kill field contents")
    ("d" ebib-delete-field-contents "delete field contents")
-   ("e" ebib-edit-field "edit field")))
+   ("e" ebib-edit-field "edit field")
+   ("v" ebib-view-field-as-help "view field as help")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -48,7 +48,10 @@
    ("e" ebib-edit-field "edit field")
    ("v" ebib-view-field-as-help "view field as help")
    ("s" ebib-insert-abbreviation "insert abbreviation")
-   ("r" ebib-toggle-raw "toggle raw")))
+   ("r" ebib-toggle-raw "toggle raw")
+   ("a" ebib-add-field "add field")
+   ("u" (lambda (_) (ebib-browse-url)) "browse url")
+   ("I" (lambda (_) (ebib-browse-doi)) "browse doi")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -37,6 +37,13 @@
 
 ;;; Code:
 
+(require 'ivy)
+(require 'ebib)
+
+(ivy-add-actions
+ 'ebib-jump-to-field
+ '(("c" ebib-copy-field-contents "copy field contents")))
+
 (provide 'ebib-ivy)
 
 ;;; ebib-notes.el ends here

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -50,7 +50,8 @@
    ("s" ebib-insert-abbreviation "insert abbreviation")
    ("r" ebib-toggle-raw "toggle raw")
    ("a" ebib-add-field "add field")
-   ("u" (lambda (_) (ebib-browse-url)) "browse url")))
+   ("u" (lambda (_) (ebib-browse-url)) "browse url")
+   ("I" (lambda (_) (ebib-browse-doi)) "browse doi")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -43,7 +43,8 @@
 (ivy-add-actions
  'ebib-jump-to-field
  '(("c" ebib-copy-field-contents "copy field contents")
-   ("k" ebib-kill-field-contents "kill field contents")))
+   ("k" ebib-kill-field-contents "kill field contents")
+   ("d" ebib-delete-field-contents "delete field contents")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -44,7 +44,8 @@
  'ebib-jump-to-field
  '(("c" ebib-copy-field-contents "copy field contents")
    ("k" ebib-kill-field-contents "kill field contents")
-   ("d" ebib-delete-field-contents "delete field contents")))
+   ("d" ebib-delete-field-contents "delete field contents")
+   ("e" ebib-edit-field "edit field")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -42,7 +42,8 @@
 
 (ivy-add-actions
  'ebib-jump-to-field
- '(("c" ebib-copy-field-contents "copy field contents")))
+ '(("c" ebib-copy-field-contents "copy field contents")
+   ("k" ebib-kill-field-contents "kill field contents")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -47,7 +47,8 @@
    ("d" ebib-delete-field-contents "delete field contents")
    ("e" ebib-edit-field "edit field")
    ("v" ebib-view-field-as-help "view field as help")
-   ("s" ebib-insert-abbreviation "insert abbreviation")))
+   ("s" ebib-insert-abbreviation "insert abbreviation")
+   ("r" ebib-toggle-raw "toggle raw")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -45,6 +45,7 @@
  '(("c" ebib-copy-field-contents "copy field contents")
    ("k" ebib-kill-field-contents "kill field contents")
    ("d" ebib-delete-field-contents "delete field contents")
+   ("y" ebib-yank-field-contents "yank field contents")
    ("e" ebib-edit-field "edit field")
    ("v" ebib-view-field-as-help "view field as help")
    ("s" ebib-insert-abbreviation "insert abbreviation")

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -50,8 +50,7 @@
    ("s" ebib-insert-abbreviation "insert abbreviation")
    ("r" ebib-toggle-raw "toggle raw")
    ("a" ebib-add-field "add field")
-   ("u" (lambda (_) (ebib-browse-url)) "browse url")
-   ("I" (lambda (_) (ebib-browse-doi)) "browse doi")))
+   ("u" (lambda (_) (ebib-browse-url)) "browse url")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -1,0 +1,42 @@
+;;; ebib-ivy.el --- Part of Ebib, a BibTeX database manager  -*- lexical-binding: t -*-
+
+;; Copyright (c) 2021 Hugo Heagren
+;; All rights reserved.
+
+;; Author: Hugo Heagren <hugo@heagren.com>
+;; Maintainer: Joost Kremers <joostkremers@fastmail.fm>
+
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright
+;;    notice, this list of conditions and the following disclaimer.
+;; 2. Redistributions in binary form must reproduce the above copyright
+;;    notice, this list of conditions and the following disclaimer in the
+;;    documentation and/or other materials provided with the distribution.
+;; 3. The name of the author may not be used to endorse or promote products
+;;    derived from this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES ; LOSS OF USE,
+;; DATA, OR PROFITS ; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+;;; Commentary:
+
+;; This file is part of Ebib, a BibTeX database manager for Emacs.  It contains
+;; the code to integrate ivy's features more tightly into the interface.
+;; To use this integration, add (require 'ebib-ivy) to init.el file.
+
+;;; Code:
+
+(provide 'ebib-ivy)
+
+;;; ebib-notes.el ends here

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -46,7 +46,8 @@
    ("k" ebib-kill-field-contents "kill field contents")
    ("d" ebib-delete-field-contents "delete field contents")
    ("e" ebib-edit-field "edit field")
-   ("v" ebib-view-field-as-help "view field as help")))
+   ("v" ebib-view-field-as-help "view field as help")
+   ("s" ebib-insert-abbreviation "insert abbreviation")))
 
 (provide 'ebib-ivy)
 

--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -47,6 +47,7 @@
    ("d" ebib-delete-field-contents "delete field contents")
    ("y" ebib-yank-field-contents "yank field contents")
    ("e" ebib-edit-field "edit field")
+   ("m" ebib--edit-multiline-field "edit multiline field")
    ("v" ebib-view-field-as-help "view field as help")
    ("s" ebib-insert-abbreviation "insert abbreviation")
    ("r" ebib-toggle-raw "toggle raw")

--- a/ebib.el
+++ b/ebib.el
@@ -202,21 +202,26 @@ If MARK is non-nil, `ebib-mark-face' is applied to the entry."
           (set-window-point (get-buffer-window) (point))
           (hl-line-highlight))))))
 
-(defun ebib--redisplay-current-field ()
-  "Redisplay the contents of the current field in the entry buffer."
+(defun ebib--redisplay-field (field)
+  "Redisplay the contents of FIELD in the current buffer."
   (with-current-ebib-buffer 'entry
     ;; If the `crossref' field has changed, we need to redisplay the entire entry.
-    (let ((field (ebib--current-field)))
       (if (cl-equalp field "crossref")
           (progn
             (ebib--update-entry-buffer)
             (re-search-forward "^crossref"))
         (let ((inhibit-read-only t))
+	  (goto-char (point-min))
+	  (re-search-forward (format "^%s" field))
           (delete-region (point-at-bol) (next-single-property-change (point) 'ebib-field-end))
           (insert (format "%-17s %s"
                           (propertize field 'face 'ebib-field-face)
                           (ebib--get-field-highlighted field (ebib--get-key-at-point))))
-          (beginning-of-line))))))
+          (beginning-of-line)))))
+
+(defun ebib--redisplay-current-field ()
+  "Redisplay the contents of the current field in the entry buffer."
+  (ebib--redisplay-field (ebib--current-field)))
 
 (defun ebib--redisplay-current-string ()
   "Redisplay the current string definition in the strings buffer."

--- a/ebib.el
+++ b/ebib.el
@@ -3812,7 +3812,7 @@ was called interactively."
       (beginning-of-line))))
 
 (defun ebib-add-field (&optional default)
-  "Prompt for a field name and add to current entry.
+  "Prompt for a field name and add it to current entry.
 If DEFAULT is specified, it is the initial input for the prompt."
   (interactive)
   (let ((field (read-string "Field: " default))

--- a/ebib.el
+++ b/ebib.el
@@ -4286,7 +4286,8 @@ FIELD is the field being edited, INIT-CONTENTS is its initial content."
 (defun ebib--edit-multiline-field (field)
   "Edit FIELD in multiline-mode.
 
-Convenience wrapper over `ebib--edit-field-as-multiline'."
+Note: this function is essentially just a convenience wrapper
+over `ebib--edit-field-as-multiline'."
   (let ((init-contents (ebib-get-field-value field (ebib--get-key-at-point) ebib--cur-db 'noerror)))
     (ebib--edit-field-as-multiline field init-contents)))
 

--- a/ebib.el
+++ b/ebib.el
@@ -3806,9 +3806,10 @@ was called interactively."
              (field (completing-read "Jump to field: " fields nil t))
              (location (save-excursion
                          (goto-char (point-min))
-                         (re-search-forward (concat "^" field)))))
-    (goto-char location)
-    (beginning-of-line)))
+                         (re-search-forward (concat "^" field) nil t))))
+    (if location
+	(goto-char location)
+      (beginning-of-line))))
 
 (defun ebib-add-field (&optional default)
   "Prompt for a field name and add to current entry.

--- a/ebib.el
+++ b/ebib.el
@@ -4297,7 +4297,7 @@ over `ebib--edit-field-as-multiline'."
   (ebib--edit-multiline-field (ebib--current-field)))
 
 (defun ebib-insert-abbreviation (field)
-  "Insert an abbreviation to FIELD from the ones defined in the database."
+  "Insert an abbreviation into FIELD from the ones defined in the database."
   (let ((key (ebib--get-key-at-point)))
     (if (ebib-get-field-value field key ebib--cur-db 'noerror)
         (beep)

--- a/ebib.el
+++ b/ebib.el
@@ -206,18 +206,18 @@ If MARK is non-nil, `ebib-mark-face' is applied to the entry."
   "Redisplay the contents of FIELD in the current buffer."
   (with-current-ebib-buffer 'entry
     ;; If the `crossref' field has changed, we need to redisplay the entire entry.
-      (if (cl-equalp field "crossref")
-          (progn
-            (ebib--update-entry-buffer)
-            (re-search-forward "^crossref"))
-        (let ((inhibit-read-only t))
-	  (goto-char (point-min))
-	  (re-search-forward (format "^%s" field))
-          (delete-region (point-at-bol) (next-single-property-change (point) 'ebib-field-end))
-          (insert (format "%-17s %s"
-                          (propertize field 'face 'ebib-field-face)
-                          (ebib--get-field-highlighted field (ebib--get-key-at-point))))
-          (beginning-of-line)))))
+    (if (cl-equalp field "crossref")
+        (progn
+          (ebib--update-entry-buffer)
+          (re-search-forward "^crossref"))
+      (let ((inhibit-read-only t))
+	(goto-char (point-min))
+	(re-search-forward (format "^%s" field))
+        (delete-region (point-at-bol) (next-single-property-change (point) 'ebib-field-end))
+        (insert (format "%-17s %s"
+                        (propertize field 'face 'ebib-field-face)
+                        (ebib--get-field-highlighted field (ebib--get-key-at-point))))
+        (beginning-of-line)))))
 
 (defun ebib--redisplay-current-field ()
   "Redisplay the contents of the current field in the entry buffer."

--- a/ebib.el
+++ b/ebib.el
@@ -3625,7 +3625,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "r" 'ebib-toggle-raw)
     (define-key map "s" 'ebib-insert-abbreviation)
     (define-key map "u" 'ebib-browse-url)
-    (define-key map "v" 'ebib-view-field-as-help)
+    (define-key map "v" 'ebib-view-current-field-as-help)
     (define-key map "y" 'ebib-yank-field-contents)
     (define-key map "\C-xb" 'ebib-quit-entry-buffer)
     (define-key map "\C-xk" 'ebib-quit-entry-buffer)
@@ -3663,7 +3663,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     "--"
     ["View File" ebib-view-file-in-field (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     ["Browse URL" ebib-browse-url (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
-    ["View Multiline Field" ebib-view-field-as-help (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
+    ["View Multiline Field" ebib-view-current-field-as-help (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     "--"
     ["Quit Entry Buffer" ebib-quit-entry-buffer t]
     ["Help On Entry Buffer" ebib-entry-help t]))
@@ -4296,11 +4296,9 @@ FIELD is the field being edited, INIT-CONTENTS is its initial content."
           (ebib--redisplay-current-field)
           (ebib-next-field))))))
 
-(defun ebib-view-field-as-help ()
-  "Show the contents of the current field in a *Help* window."
-  (interactive)
-  (let ((help-window-select t)                          ; Make sure the help window is selected.
-        (field (ebib--current-field)))
+(defun ebib-view-field-as-help (field)
+  "Show the contents of the FIELD in a *Help* window."
+  (let ((help-window-select t))                          ; Make sure the help window is selected.
     (with-help-window (help-buffer)
       (princ (propertize (format "%s" field) 'face '(:weight bold)))
       (princ "\n\n")
@@ -4308,6 +4306,11 @@ FIELD is the field being edited, INIT-CONTENTS is its initial content."
         (if contents
             (princ contents)
           (princ "[Empty field]"))))))
+
+(defun ebib-view-current-field-as-help ()
+  "Show the contents of the current field in a *Help* window."
+  (interactive)
+  (ebib-view-field-as-help (ebib--current-field)))
 
 (defun ebib-entry-help ()
   "Show the info node for Ebib's entry buffer."

--- a/ebib.el
+++ b/ebib.el
@@ -3810,10 +3810,12 @@ was called interactively."
     (goto-char location)
     (beginning-of-line)))
 
-(defun ebib-add-field (field)
-  "Add FIELD to the current entry."
-  (interactive "sField: ")
-  (let ((key (ebib--get-key-at-point)))
+(defun ebib-add-field (&optional default)
+  "Prompt for a field name and add to current entry.
+If DEFAULT is specified, it is the initial input for the prompt."
+  (interactive)
+  (let ((field (read-string "Field: " default))
+	(key (ebib--get-key-at-point)))
     (if (ebib-get-field-value field key ebib--cur-db 'noerror)
         (error "[Ebib] Field `%s' already has a value in entry `%s'" field key)
       ;; We store the field with an empty string as value and then let the user

--- a/ebib.el
+++ b/ebib.el
@@ -2836,7 +2836,7 @@ new database."
           (forward-line -1))
         (ebib-select-and-popup-entry)))))
 
-(defun ebib-browse-url (arg)
+(defun ebib-browse-url (&optional arg)
   "Browse the URL in the \"url\" field.
 If the \"url\" field contains more than one URL, ask the user
 which one to open.  Alternatively, the user can provide a numeric

--- a/ebib.el
+++ b/ebib.el
@@ -4314,7 +4314,7 @@ over `ebib--edit-field-as-multiline'."
           (ebib-next-field))))))
 
 (defun ebib-insert-abbreviation-current-field ()
-  "Insert an abbreviation from the database to current field."
+  "Insert an abbreviation into current field from the ones defined the database ."
   (interactive)
   (ebib-insert-abbreviation (ebib--current-field)))
 

--- a/ebib.el
+++ b/ebib.el
@@ -3623,7 +3623,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map [(meta p)] 'ebib-goto-next-set)
     (define-key map "q" 'ebib-quit-entry-buffer)
     (define-key map "r" 'ebib-toggle-raw)
-    (define-key map "s" 'ebib-insert-abbreviation)
+    (define-key map "s" 'ebib-insert-abbreviation-current-field)
     (define-key map "u" 'ebib-browse-url)
     (define-key map "v" 'ebib-view-current-field-as-help)
     (define-key map "y" 'ebib-yank-field-contents)
@@ -3651,7 +3651,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
   '("Ebib"
     ["Edit Field" ebib-edit-current-field t]
     ["Edit Field As Multiline" ebib-edit-multiline-field t]
-    ["Insert @String Abbreviation" ebib-insert-abbreviation]
+    ["Insert @String Abbreviation" ebib-insert-abbreviation-current-field]
     ["Toggle Raw" ebib-toggle-raw (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     "--"
     ["Kill Field Contents" ebib-kill-current-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
@@ -4277,11 +4277,9 @@ FIELD is the field being edited, INIT-CONTENTS is its initial content."
     (error "[Ebib] Cannot edit a raw field as multiline"))
    (t (ebib--multiline-edit (list 'field (ebib-db-get-filename ebib--cur-db) (ebib--get-key-at-point) field) (ebib-unbrace init-contents)))))
 
-(defun ebib-insert-abbreviation ()
-  "Insert an abbreviation from the ones defined in the database."
-  (interactive)
-  (let ((key (ebib--get-key-at-point))
-        (field (ebib--current-field)))
+(defun ebib-insert-abbreviation (field)
+  "Insert an abbreviation to FIELD from the ones defined in the database."
+  (let ((key (ebib--get-key-at-point)))
     (if (ebib-get-field-value field key ebib--cur-db 'noerror)
         (beep)
       (let ((strings (ebib-db-list-strings ebib--cur-db)))
@@ -4293,8 +4291,13 @@ FIELD is the field being edited, INIT-CONTENTS is its initial content."
                 (ebib--set-modified t ebib--cur-db t (seq-filter (lambda (dependent)
                                                                    (ebib-db-has-key key dependent))
                                                                  (ebib--list-dependents ebib--cur-db))))))
-          (ebib--redisplay-current-field)
+          (ebib--redisplay-field field)
           (ebib-next-field))))))
+
+(defun ebib-insert-abbreviation-current-field ()
+  "Insert an abbreviation from the database to current field."
+  (interactive)
+  (ebib-insert-abbreviation (ebib--current-field)))
 
 (defun ebib-view-field-as-help (field)
   "Show the contents of the FIELD in a *Help* window."

--- a/ebib.el
+++ b/ebib.el
@@ -3605,7 +3605,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "a" 'ebib-add-field)
     (define-key map "b" 'ebib-goto-prev-set)
     (define-key map "c" 'ebib-copy-current-field-contents)
-    (define-key map "d" 'ebib-delete-field-contents)
+    (define-key map "d" 'ebib-delete-current-field-contents)
     (define-key map "e" 'ebib-edit-field)
     (define-key map "f" 'ebib-view-file-in-field)
     (define-key map "g" 'ebib-goto-first-field)
@@ -3657,7 +3657,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     ["Kill Field Contents" ebib-kill-current-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     ["Copy Field Contents" ebib-copy-current-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     ["Yank" ebib-yank-field-contents t]
-    ["Delete Field Contents" ebib-delete-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
+    ["Delete Field Contents" ebib-delete-current-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     "--"
     ["Add Field" ebib-add-field t]
     "--"
@@ -4208,22 +4208,26 @@ argument ARG functions as with \\[yank] / \\[yank-pop]."
                                                              (ebib-db-has-key key dependent))
                                                            (ebib--list-dependents ebib--cur-db))))))))
 
-(defun ebib-delete-field-contents ()
-  "Delete the contents of the current field.
+(defun ebib-delete-field-contents (field)
+  "Delete the contents of FIELD.
 The deleted text is not put in the kill ring."
-  (interactive)
-  (let ((key (ebib--get-key-at-point))
-        (field (ebib--current-field)))
+  (let ((key (ebib--get-key-at-point)))
     (if (string= field "=type=")
         (beep)
       (when (y-or-n-p "Delete field contents? ")
         (ebib-db-remove-field-value field key ebib--cur-db)
-        (ebib--redisplay-current-field)
+        (ebib--redisplay-field field)
         (ebib--redisplay-index-item field)
         (ebib--set-modified t ebib--cur-db t (seq-filter (lambda (dependent)
                                                            (ebib-db-has-key key dependent))
                                                          (ebib--list-dependents ebib--cur-db)))
         (message "Field contents deleted.")))))
+
+(defun ebib-delete-current-field-contents ()
+    "Delete the contents of the current field.
+The deleted text is not put in the kill ring."
+    (interactive)
+    (ebib-delete-field-contents (ebib--current-field)))
 
 (defun ebib-toggle-raw ()
   "Toggle the \"special\" status of the current field contents."

--- a/ebib.el
+++ b/ebib.el
@@ -3599,7 +3599,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map " " 'ebib-goto-next-set)
     (define-key map "a" 'ebib-add-field)
     (define-key map "b" 'ebib-goto-prev-set)
-    (define-key map "c" 'ebib-copy-field-contents)
+    (define-key map "c" 'ebib-copy-current-field-contents)
     (define-key map "d" 'ebib-delete-field-contents)
     (define-key map "e" 'ebib-edit-field)
     (define-key map "f" 'ebib-view-file-in-field)
@@ -3649,8 +3649,8 @@ hook `ebib-reading-list-remove-item-hook' is run."
     ["Insert @String Abbreviation" ebib-insert-abbreviation]
     ["Toggle Raw" ebib-toggle-raw (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     "--"
-    ["Copy Field Contents" ebib-copy-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     ["Kill Field Contents" ebib-kill-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
+    ["Copy Field Contents" ebib-copy-current-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     ["Yank" ebib-yank-field-contents t]
     ["Delete Field Contents" ebib-delete-field-contents (ebib-db-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror)]
     "--"
@@ -4127,19 +4127,24 @@ viewed."
         (while (ebib--line-at-point)
           (forward-line direction))))))
 
-(defun ebib-copy-field-contents ()
-  "Copy the contents of the current field to the kill ring.
+(defun ebib-copy-field-contents (field)
+  "Copy the contents of FIELD to the kill ring.
 If the field contains a value from a cross-referenced entry, that
 value is copied to the kill ring."
-  (interactive)
-  (let ((field (ebib--current-field)))
     (unless (or (not field)
                 (string= field "=type="))
       (let ((contents (ebib-get-field-value field (ebib--get-key-at-point) ebib--cur-db 'noerror 'unbraced 'xref)))
         (if (stringp contents)
             (progn (kill-new contents)
                    (message "Field contents copied."))
-          (error "Cannot copy an empty field"))))))
+          (error "Cannot copy an empty field")))))
+
+(defun ebib-copy-current-field-contents ()
+  "Copy the contents of the current field to the kill ring.
+If the field contains a value from a cross-referenced entry, that
+value is copied to the kill ring."
+  (interactive)
+  (ebib-copy-field-contents (ebib--current-field)))
 
 (defun ebib-kill-field-contents ()
   "Kill the contents of the current field.

--- a/ebib.el
+++ b/ebib.el
@@ -4020,14 +4020,14 @@ string in the minibuffer."
 Most fields are edited directly using the minibuffer, but a few
 are handled specially: the `type' `crossref', `xref' and
 `related' fields offer completion, the `annote', `annotation' and
-`abstract' fields is edited as a multiline field, the `keywords'
+`abstract' fields are edited as a multiline field, the `keywords'
 field adds keywords one by one, also allowing completion, and the
 \"file\" field uses filename completion and shortens filenames if
 they are in (a subdirectory of) one of the directories in
 `ebib-file-search-dirs'.
 
 With a prefix argument, edit the current field directly, without
-any special treatment. Exceptions are the \"type\" field and any
+any special treatment.  Exceptions are the \"type\" field and any
 field with a multiline value, which are always edited in a
 special manner."
   (let* ((pfx current-prefix-arg)
@@ -4091,7 +4091,7 @@ special manner."
 Most fields are edited directly using the minibuffer, but a few
 are handled specially: the `type' `crossref', `xref' and
 `related' fields offer completion, the `annote', `annotation' and
-`abstract' fields is edited as a multiline field, the `keywords'
+`abstract' fields are edited as multiline fields, the `keywords'
 field adds keywords one by one, also allowing completion, and the
 \"file\" field uses filename completion and shortens filenames if
 they are in (a subdirectory of) one of the directories in


### PR DESCRIPTION
This pull request adds ivy actions to ebib-jump-to-field, on keys respective of those for actions are available in the entry buffer.

Resolves #210 

I've implemented `copy-field-contents` and that was pretty straightforward. The other actions (kill, delete, yank, etc.) will be a bit more involved because I'll need to modify some of the other helper functions to take a field argument and propogate all of those changes properly. I thought I would start with a draft PR so that you could see what I've got and how I'm doing it as I go along.

***

Edit, a running list of implemented functions is useful:

- [x] ebib-copy-field-contents
- [x] ebib-kill-field-contents
- [x] ebib-yank-field-contents
- [x] ebib-delete-field-contents
- [x] ebib-edit-field
- [x] ebib-edit-multiline-field
- [x] ebib-view-field-as-help
- [x] ebib-insert-abbreviation
- [x] ebib-browse-url
- [x] ebib-browse-doi
- [x] ebib-toggle-raw
- [x] ebib-add-field