### PR TITLE
Display abbreviation values in entry buffer

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1094,6 +1094,10 @@ file.  If this option is set, the database is automatically saved."
   "Face used to indicate values inherited from crossreferenced entries."
   :group 'ebib-faces)
 
+(defface ebib-abbrev-face '((t  (:inherit font-lock-regexp-grouping-construct)))
+  "Face used to indicate expanded abbreviated/concatenated strings."
+  :group 'ebib-faces)
+
 (defface ebib-marked-face '((t (:inverse-video t)))
   "Face to indicate marked entries."
   :group 'ebib-faces)

--- a/ebib.el
+++ b/ebib.el
@@ -375,7 +375,7 @@ which can be passed to `ebib--display-multiline-field'."
   "Return the contents of FIELD in entry KEY in DB with MATCH-STR highlighted."
   (or db (setq db ebib--cur-db))
   (let* ((case-fold-search t)
-         (value (ebib-get-field-value field key db 'noerror nil 'xref))
+         (value (ebib-get-field-value field key db 'noerror nil 'xref 'expand-strings))
          (multiline "")
          (raw " ")
          (matched nil)
@@ -388,6 +388,8 @@ which can be passed to `ebib--display-multiline-field'."
     (when value
       (if (get-text-property 0 'ebib--alias value)
           (setq alias (propertize (format "  [<== %s]" (cdr (assoc-string field ebib--field-aliases 'case-fold))) 'face 'ebib-alias-face)))
+      (if (get-text-property 0 'ebib--expanded value)
+          (setq value (propertize value 'face 'ebib-abbrev-face 'fontified t)))
       (if (stringp (get-text-property 0 'ebib--xref value))
           (setq value (propertize value 'face 'ebib-crossref-face 'fontified t)))
       (if (and (member-ignore-case field '("crossref" "xref" "related"))


### PR DESCRIPTION
Knocked this up just now and I thought it might be useful. I started using strings for the first time today, and realised that once you get going, it can be hard to remember what strings display what and know what information you actually have in an entry.

This PR displays the expanded values of abbreviations and concatenations in the entry buffer, rather than the raw text itself (similar to crossreferenced field behaviour). The fields are still marked as special, and the expanded text comes up in `ebib-alias-face`, which seemed appropriate (and also meant I didn't have to define a new face). Editing the value still brings up the actual value in the entry itself (the short abbreviations and concatenations with '#'). To do this I had to add an option to `ebib-get-field-value`, but its optional and comes at the end of the arg list, so any other uses are not affected.

Example usage: say I define two abbreviations: `o = {Oxford}` and `up = {University Press}`. I could then have an entry with a field value `publisher = o # " " # up`. This would display in the entry in `ebib-alias-face` as `Oxford University Press`, and the field would be marked as special/raw. If I went to edit the field though, `o # " " # up` would show up in the minibuffer.

I find this really useful, but if some users don't it would be pretty simple to add a user option to turn this behaviour off? Could also add a specific face for displaying strings if that would be useful.

EDIT: Worked so hard on this only to realise there's an edge case. This doesn't display the expanded values in aliassed field (e.g. if an abbreviation is used as the `journal` field, the raw value shows up in `journaltitle`, not the expanded value). I can't quite work out how aliases are handled, so I can't see how a fix would look. If you think this PR is worth it, it would be nice to cover this case before it goes in, could you suggest where I might look?