### PR TITLE
add slash to ebib-import-directory

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -889,7 +889,7 @@ to handle a URL on the command line."
 
 (make-obsolete-variable 'ebib-file-field "The standard file field can no longer be customized" "Ebib 2.27")
 
-(defcustom ebib-import-directory "~/Downloads"
+(defcustom ebib-import-directory "~/Downloads/"
   "Directory to import files from.
 When using the command `ebib-import-file', this directory is
 offered as the default directory."


### PR DESCRIPTION
<img width="867" alt="Screen Shot 2021-11-12 at 10 08 02" src="https://user-images.githubusercontent.com/13161779/141397006-35797da9-ab64-4d50-8d4a-f7e9f7df9732.png">

usually completions are not shown without slash