### PR TITLE
Recursive strings

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -2015,17 +2015,22 @@ inherit a value, this function returns nil."
 ;; `ebib-db.el' cannot depend on `ebib-utils.el' (because `ebib-utils.el' already depends on
 ;; `ebib-db.el').  Similar considerations apply to `ebib-get-string' below.
 
-(defun ebib-set-string (abbr value db &optional overwrite)
+(defun ebib-set-string (abbr value db &optional overwrite nobrace)
   "Set the @string definition ABBR to VALUE in database DB.
 If ABBR does not exist, create it.  OVERWRITE functions as in
 `ebib-db-set-string'.  VALUE is enclosed in braces if it isn't
 already.
 
+If NOBRACE is t, the value is stored without braces.  If it is
+nil, braces are added if not already present.  NOBRACE may also be
+the symbol ‘as-is’, in which case the value is stored as is.
+
 This function basically just calls `ebib-db-set-string' to do the
   real work."
-  (ebib-db-set-string abbr (if (ebib-unbraced-p value)
-                               (ebib-brace value)
-                             value)
+  (ebib-db-set-string abbr (cl-case nobrace
+			     (as-is value)
+			     (t (ebib-unbrace value))
+			     (nil (ebib-brace value)))
                       db overwrite))
 
 (defun ebib-get-string (abbr db &optional noerror unbraced)

--- a/ebib.el
+++ b/ebib.el
@@ -1394,7 +1394,7 @@ Return value is the string if one was read, nil otherwise."
            (abbr (car def))
            (string (cdr def)))
       (if def
-          (if (ebib-set-string abbr string db)
+          (if (ebib-set-string abbr string db nil 'as-is)
               string
             (ebib--log 'warning (format "Line %d: @String definition `%s' duplicated. Skipping."
                                         (line-number-at-pos) abbr)))


### PR DESCRIPTION
Fixe #236.

A number of internal api changes, roughly as [here](https://github.com/joostkremers/parsebib/issues/16#issuecomment-1004645284).

The overall effect is that it is now possible to expand a string (as might be found in a field value) into its final printable version recursively, following all the rules that bib(la)tex would. In particular:
- multiple `#` characters (or `#` at the end of a string) are not allowed
- strings consisting entirely of digits [do not need to be expanded](https://tex.stackexchange.com/questions/629260/which-fields-have-to-be-braced-or-quoted-in-bib-files-why-does-year-not-ha/629266#629266)
- braces and quote marks can be escaped with `\`
- braces must match, unless they appear inside "quo{tes"

Must say, the code isn't pretty, but it does work and I'm quite proud that I managed to get it to work.

For the user all that changes is that all strings are correctly (and completely) expanded in the entry buffer. As before, a special face is added to the text if it is expanded (see the docstring of `ebib--expand-string`). I moved this functionality to `ebib--expand-string` in anticipation of it being useful for other things (e.g. displaying full expansions in the string buffer as well, mentioned [here](https://github.com/joostkremers/parsebib/issues/16#issuecomment-996283938)). 