### PR TITLE
ebib-get-field-value: fix date regex to allow [:-/] chars

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1902,7 +1902,7 @@ string has the text property `ebib--alias' with value t."
 		 ;; Fields consisting of only numerical values can be
 		 ;; written without bracing or quotes, and not be
 		 ;; expanded. Only continue if the value is not so.
-		 (not (string-match "\\`[[:digit:]]+\\'" value))
+		 (not (string-match "\\`[[:digit:]:/-]+\\'" value))
 		 (or (eq ebib-expand-strings t)
 		     (assoc-string field ebib-expand-strings 'case-fold)
 		     (assoc-string alias ebib-expand-strings 'case-fold)))


### PR DESCRIPTION
Quick fix for a bad bug I noticed today. Biblatex allows quite complex date specifications, including using `/`,`:` and `-` to separate different types of elemtents. The regex needed to include these.