### PR TITLE
ebib--expand-string: remove redundant `dbus-byte-array-to-string`

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -2073,7 +2073,7 @@ the returned string has the face `ebib-abbrev-face'."
 	   ;; repeated '#' characters)...
 	   unless (string-empty-p (string-trim curr-section))
 	   ;; ...then add it to the list of strings.
-	   collect (let ((curr-string (string-trim (dbus-byte-array-to-string curr-section))))
+	   collect (let ((curr-string (string-trim curr-section)))
 		     (if (ebib-unbraced-p curr-string)
 			 ;; Recur if string not quoted
 			 (progn (setq expanded t)


### PR DESCRIPTION
Fix #245. My past self didn't understand arrays and strings in elisp properly and the function is actually entirely redundant.

Commit message:
> Strings just are arrays, so this doesn't do anything useful, and adds
> extra dependency for users.