### PR TITLE
ebib-delete-field-contents: keep ebib--notes-list up to date

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -4228,7 +4228,9 @@ entry, it is never killed."
 	(when kill (kill-new contents))
 	(if external
 	    (if (eq ebib-notes-storage 'one-file-per-note)
-		(delete-file (expand-file-name (ebib--create-notes-file-name key)))
+		(progn
+		  (delete-file (expand-file-name (ebib--create-notes-file-name key)))
+		  (delete key ebib--notes-list))
 	      (error "[Ebib] `ebib-notes-storage' set to `%s', deleting not supported.
 Try opening the note file and deleting it manually." ebib-notes-storage))
 	  (ebib-db-remove-field-value field key ebib--cur-db))


### PR DESCRIPTION
I have a status icon in my index display for whether an entry has notes, and I realised it didn't update when I deleted a note (which it should). I realised this was because when notes are deleted, the relevant entries' keys are never removed from the running list kept in `ebib--notes-list`. Fix this.

Original commit message:

> When a note file is deleted, remove the current entry's key from
> ebib's internal list of which entries have notes.