### PR TITLE
ebib--redisplay-strings-buffer: adjust rx for back-compatibility

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -257,7 +257,8 @@ If MARK is non-nil, `ebib-mark-face' is applied to the entry."
 	  (string (ebib--current-string)))
       (erase-buffer)
       (ebib--fill-strings-buffer)
-      (re-search-forward (rx line-start (literal string) (syntax -))))))
+      (re-search-forward
+       (rx-to-string `(: line-start ,string (syntax -)) t)))))
 
 (defun ebib--convert-multiline-to-string (multilines)
   "Convert MULTILINES to a single multiline string.


### PR DESCRIPTION
Fix #249. Commit message below:

> The `string' rx construct is relatively and not present in
> still-supported older versions of emacs. Use an alternative method
> which should achieve the same thing.