### PR TITLE
Feature request: use `completing-read-multiple` for editting fields with multiple values and completion (file, publishers etc.)

### DIFF
--- a/ebib-ivy.el
+++ b/ebib-ivy.el
@@ -49,7 +49,7 @@
    ("d" ebib-delete-field-contents "delete field contents")
    ("y" ebib-yank-field-contents "yank field contents")
    ("e" ebib-edit-field "edit field")
-   ("m" ebib--edit-multiline-field "edit multiline field")
+   ("m" ebib--edit-field-as-multiline "edit multiline field")
    ("v" ebib-view-field-as-help "view field as help")
    ("s" ebib-insert-abbreviation "insert abbreviation")
    ("r" ebib-toggle-raw "toggle raw")

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1117,7 +1117,7 @@ Ebib (not Emacs)."
 (make-obsolete-variable 'ebib-fields-with-completion 'ebib-field-edit-functions "Ebib 2.34")
 
 (defcustom ebib-field-edit-functions '((("abstract" "addendum" "note" "annotation")
-					. ebib--edit-literal-field-multiline)
+					. ebib--edit-field-as-multiline)
 				       (("afterword" "annotator" "author" "bookauthor"
 					 "commentator" "editor" "editora" "editorb"
 					 "editorc" "foreword" "holder" "introduction"

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1131,6 +1131,11 @@ three arguments: the field to be edited, the complete list of
 fields in the car and the original contents of the field as a
 string as a string if non-empty, or nil otherwise.
 
+If the original contents of the field being edited were braced,
+`ebib-edit-field' will preserve this bracing, but will pass an
+unbraced string to the relevant function. As such, the functions
+should not handle bracing.
+
 Functions should prompt for a value, using the name of the edited
 field in the prompt string, and completing on values of the
 fields in the list where appropriate. They should return a

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1114,17 +1114,30 @@ Ebib (not Emacs)."
                  (const :tag "Show the cursor" nil)))
 
 (make-obsolete-variable 'ebib-edit-author/editor-without-completion 'ebib-fields-with-completion "Ebib 2.27")
+(make-obsolete-variable 'ebib-fields-with-completion 'ebib-field-edit-functions "Ebib 2.34")
 
-(defcustom ebib-fields-with-completion '("author" "crossref" "file" "keywords" "journal" "journaltitle" "organization" "publisher")
-  "Fields that are edited using completion.
-When editing a field in this list, Ebib offers a sensible set of
-possible completion candidates (see the manual for details).
+(defcustom ebib-field-edit-functions '((("author" "editor")	      . ebib--edit-list-field)
+				       (("crossref" "xref" "related") . ebib--edit-key-field)
+				       (("file")		      . ebib--edit-file-field)
+				       (("keywords")		      . ebib--edit-separated-values-field)
+				       (("journal" "journaltitle")    . ebib--edit-literal-field)
+				       (("organization")	      . ebib--edit-list-field)
+				       (("publisher")		      . ebib--edit-list-field))
+  "Alist of completion functions for fields.
+The car of each element is a list of fields, which must all have
+the same BibLaTeX type. When any of the fields is edited, the
+completion function in the cdr of the element is called with
+three arguments: the field to be edited, the complete list of
+fields in the car and the original contents of the field as a
+string as a string if non-empty, or nil otherwise.
 
-Note that the \"author\" field also implies the \"editor\" field
-and that \"crossref\" also implies the \"xref\" and \"related\"
-fields."
+Functions should prompt for a value, using the name of the edited
+field in the prompt string, and completing on values of the
+fields in the list where appropriate. They should return a
+string, suitable as a field value."
   :group 'ebib
-  :type '(repeat (string :tag "Field")))
+  :type '(repeat (cons (repeat (string) :tag "Fields")
+		       (function :tag "Completion function"))))
 
 (defcustom ebib-multiline-fields '("annote" "annotation" "abstract")
   "Fields that are edited as multiline fields by default."

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1137,7 +1137,7 @@ Ebib (not Emacs)."
 				       (("organization")	      . ebib--edit-list-field)
 				       (("publisher" "origpublisher") . ebib--edit-list-field)
 				       (("pubstate")                  . ebib--edit-pubstate-field)
-				       (("related" "xdata")           . ebib--edit-ref-list-field)
+				       (("related" "xdata" "entryset") . ebib--edit-ref-list-field)
 				       (("venue")                     . ebib--edit-literal-field))
   "Alist of completion functions for fields.
 The car of each element is a list of fields, which must all have

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1127,6 +1127,7 @@ Ebib (not Emacs)."
 				       (("crossref" "xref")           . ebib--edit-ref-field)
 				       (("editortype" "editoratype" "editorbtype" "editorctype")
 					. ebib--edit-editor-type-field)
+				       (("execute")                   . ebib--edit-TeX-code-field)
 				       (("file")		      . ebib--edit-file-field)
 				       (("institution")               . ebib--edit-list-field)
 				       (("journal" "journaltitle")    . ebib--edit-literal-field)

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1116,7 +1116,8 @@ Ebib (not Emacs)."
 (make-obsolete-variable 'ebib-edit-author/editor-without-completion 'ebib-fields-with-completion "Ebib 2.27")
 (make-obsolete-variable 'ebib-fields-with-completion 'ebib-field-edit-functions "Ebib 2.34")
 
-(defcustom ebib-field-edit-functions '((("abstract" "addendum" "note") . ebib--edit-literal-field-multiline)
+(defcustom ebib-field-edit-functions '((("abstract" "addendum" "note" "annotation")
+					. ebib--edit-literal-field-multiline)
 				       (("afterword" "annotator" "author" "bookauthor"
 					 "commentator" "editor" "editora" "editorb"
 					 "editorc" "foreword" "holder" "introduction"

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1116,13 +1116,28 @@ Ebib (not Emacs)."
 (make-obsolete-variable 'ebib-edit-author/editor-without-completion 'ebib-fields-with-completion "Ebib 2.27")
 (make-obsolete-variable 'ebib-fields-with-completion 'ebib-field-edit-functions "Ebib 2.34")
 
-(defcustom ebib-field-edit-functions '((("author" "editor")	      . ebib--edit-list-field)
-				       (("crossref" "xref" "related") . ebib--edit-key-field)
+(defcustom ebib-field-edit-functions '((("abstract" "addendum" "note") . ebib--edit-literal-field-multiline)
+				       (("afterword" "annotator" "author" "bookauthor"
+					 "commentator" "editor" "editora" "editorb"
+					 "editorc" "foreword" "holder" "introduction"
+					 "sortname" "translator")
+					. ebib--edit-list-field)
+				       (("bookpagination" "pagination") . ebib--edit-pagination-field)
+				       (("crossref" "xref")           . ebib--edit-ref-field)
+				       (("editortype" "editoratype" "editorbtype" "editorctype")
+					. ebib--edit-editor-type-field)
 				       (("file")		      . ebib--edit-file-field)
-				       (("keywords")		      . ebib--edit-separated-values-field)
+				       (("institution")               . ebib--edit-list-field)
 				       (("journal" "journaltitle")    . ebib--edit-literal-field)
+				       (("keywords")		      . ebib--edit-separated-values-field)
+				       (("langid")                    . ebib--edit-lang-id-field)
+				       (("language" "origlanguage")   . ebib--edit-language-field)
+				       (("location" "origlocation")   . ebib--edit-literal-field)
 				       (("organization")	      . ebib--edit-list-field)
-				       (("publisher")		      . ebib--edit-list-field))
+				       (("publisher" "origpublisher") . ebib--edit-list-field)
+				       (("pubstate")                  . ebib--edit-pubstate-field)
+				       (("related" "xdata")           . ebib--edit-ref-list-field)
+				       (("venue")                     . ebib--edit-literal-field))
   "Alist of completion functions for fields.
 The car of each element is a list of fields, which must all have
 the same BibLaTeX type. When any of the fields is edited, the

--- a/ebib.el
+++ b/ebib.el
@@ -4134,6 +4134,28 @@ special manner."
                                         (ebib-db-has-key key dependent))
                                       (ebib--list-dependents ebib--cur-db))))))
 
+(defun ebib--edit-literal-field (field-name fields init-contents &optional &rest extra-tables)
+  "Edit a 'literal' type field.
+FIELD-NAME is the name of the field being edited. FIELDS is a
+list of fields from which to pull completion candidates.
+INIT-CONTENTS is the original value of the field. See also
+`ebib-field-edit-functions'.
+
+EXTRA-TABLES are extra completion tables to be included in the
+candidate list, alongside the candidates generated from FIELDS.
+This argument is useful for fields which have a canonical
+list of candidates, like \"pubstate\".
+
+See also `ebib-field-edit-functions'."
+  (completing-read
+   (format "%s: " field-name)
+   (apply #'completion-table-merge
+	  `(,(ebib--create-collection-from-fields fields)
+	    ,@extra-tables))
+   (lambda (str) (not (string-empty-p str))) ;; predicate
+   nil					;; require-match
+   init-contents))                      ;; initial-input
+
 (defun ebib-edit-current-field ()
   "Edit current field of a BibTeX entry.
 Most fields are edited directly using the minibuffer, but a few

--- a/ebib.el
+++ b/ebib.el
@@ -4227,6 +4227,14 @@ See also `ebib-field-edit-functions'."
 		     crm-char)))))
     (string-join result " and ")))
 
+(defun ebib--edit-language-field (field-name fields init-contents)
+  "Edit \"language\" field.
+
+Arguments are as in `ebib--edit-list-field'."
+  (ebib--edit-list-field
+   field-name fields init-contents
+   ebib--biblatex-language-keys))
+
 (defun ebib-edit-current-field ()
   "Edit current field of a BibTeX entry.
 Most fields are edited directly using the minibuffer, but a few

--- a/ebib.el
+++ b/ebib.el
@@ -4102,23 +4102,9 @@ special manner."
 		  ;; a cond.
                   (pfx
                    (ebib--edit-normal-field field init-contents))
-                  ((and (member-ignore-case field '("author" "editor"))
-                        (member-ignore-case "author" ebib-fields-with-completion))
-                   (ebib--edit-author/editor-field field))
-                  ((and (member-ignore-case field '("crossref" "xref" "related"))
-                        (member-ignore-case "crossref" ebib-fields-with-completion))
-                   (ebib--edit-crossref field))
-                  ((and (cl-equalp field "keywords")
-                        (member-ignore-case "keywords" ebib-fields-with-completion))
-                   (ebib--edit-keywords-field))
-                  ((and (cl-equalp field "file")
-                        (member-ignore-case "file" ebib-fields-with-completion))
-                   (ebib--edit-file-field))
-                  ((member-ignore-case field ebib-fields-with-completion)
-                   (ebib--edit-normal-field field init-contents :complete))
-                  ((member-ignore-case field ebib-multiline-fields)
-                   (ebib--edit-field-as-multiline field init-contents)
-                   nil) ; See above.
+		  ((when-let ((data (assoc field ebib-field-edit-functions
+					   (lambda (a b) (member-ignore-case b a)))))
+		     (funcall (cdr data) field (car data) init-contents)))
                   ;; An external note is shown in the field "external note", but
                   ;; `ebib--current-field' only reads up to the first space, so
                   ;; it just returns "external".

--- a/ebib.el
+++ b/ebib.el
@@ -4128,7 +4128,11 @@ special manner."
       (ebib-set-field-value field result key ebib--cur-db 'overwrite (ebib-unbraced-p init-contents))
       (when pfx (ebib-next-field))
       (ebib--redisplay-field field)
-      (ebib--redisplay-index-item field))))
+      (ebib--redisplay-index-item field)
+      (ebib--set-modified t ebib--cur-db t
+			  (seq-filter (lambda (dependent)
+                                        (ebib-db-has-key key dependent))
+                                      (ebib--list-dependents ebib--cur-db))))))
 
 (defun ebib-edit-current-field ()
   "Edit current field of a BibTeX entry.

--- a/ebib.el
+++ b/ebib.el
@@ -4195,6 +4195,23 @@ Arguments are as in `ebib--edit-literal-field'."
    '("inpreparation" "submitted"
      "forthcoming" "inpress" "prepublished")))
 
+(defun ebib--read-ref-as-entry (prompt databases &optional multiple)
+  "Read entry keys from user.
+
+Arguments are as in `ebib-read-entry', except that
+`ebib-citation-insert-multiple' is ignored when reading multiple
+candidates.
+
+If MULTIPLE is nil, the key is returned as a string, If non-nil,
+all selected keys are returned as a list of strings."
+  (let* ((ebib-citation-insert-multiple t)
+	(entry (ebib-read-entry
+		(format "%s: " prompt) databases
+		multiple)))
+    (if multiple
+	(mapcar #'car entry)
+      (caar entry))))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4086,8 +4086,9 @@ With a prefix argument, edit the current field directly, without
 any special treatment.  Exceptions are the \"type\" field and any
 field with a multiline value, which are always edited in a
 special manner."
-  (let* ((pfx current-prefix-arg)
-         (init-contents (ebib-get-field-value field (ebib--get-key-at-point) ebib--cur-db 'noerror))
+  (let* ((key (ebib--get-key-at-point))
+	 (pfx current-prefix-arg)
+         (init-contents (ebib-get-field-value field key ebib--cur-db 'noerror))
          ;; We relegate the actual editing to a number of helper functions.
          ;; These functions should return non-nil if editing was successful.
          ;; They should also ensure that the field being edited is redisplayed
@@ -4124,6 +4125,7 @@ special manner."
       ;; A numeric prefix argument is always non-nil when a command is called
       ;; interactively, so `pfx' can only be nil if `ebib-edit-field' is called
       ;; from Lisp code.
+      (ebib-set-field-value field result key ebib--cur-db)
       (when pfx (ebib-next-field))
       (ebib--redisplay-field field)
       (ebib--redisplay-index-item field))))

--- a/ebib.el
+++ b/ebib.el
@@ -4156,6 +4156,14 @@ See also `ebib-field-edit-functions'."
    nil					;; require-match
    init-contents))                      ;; initial-input
 
+(defun ebib--edit-editor-type-field (field-name fields init-contents)
+  "Edit \"editor-type\" field.
+Arguments are as in `ebib--edit-literal-field'."
+  (ebib--edit-literal-field
+   field-name fields init-contents
+   '("editor" "compiler" "founder" "continuator"
+     "redactor" "reviser" "collaborator" "organizer")))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4319,6 +4319,13 @@ See also `ebib-field-edit-functions'."
 		  (when init-contents (concat init-contents ", ")))))
     (string-join result ", ")))
 
+(defun ebib--edit-TeX-code-field (field-name _fields _init-contents)
+  "Edit FIELD-NAME in a multline `tex-mode' buffer.
+_FIELDS and _INIT-CONTENTS are ignored, because
+`ebib--edit-field-as-multiline' ignores them."
+  (let ((ebib-multiline-major-mode 'tex-mode))
+    (ebib--edit-field-as-multiline field-name)))
+
 (defun ebib-edit-current-field ()
   "Edit current field of a BibTeX entry.
 Most fields are edited directly using the minibuffer, but a few

--- a/ebib.el
+++ b/ebib.el
@@ -4092,7 +4092,7 @@ special manner."
          (result (cond
                   ((string= field "=type=") (ebib--edit-entry-type))
                   ((ebib--multiline-p init-contents)
-                   (ebib--edit-field-as-multiline field init-contents)
+                   (ebib--edit-field-as-multiline field)
                    ;; A multiline edit differs from the other fields, because
                    ;; the edit isn't done when `ebib--edit-field-as-multiline'
                    ;; returns. This means we cannot move to the next field.  For
@@ -4510,28 +4510,27 @@ argument ARG functions as with \\[yank] / \\[yank-pop]."
   (interactive)
   (ebib-toggle-raw (ebib--current-field)))
 
-(defun ebib--edit-field-as-multiline (field init-contents)
+(defun ebib--edit-field-as-multiline (field &optional _fields _init-contents)
   "Edit a field in multiline-mode.
-FIELD is the field being edited, INIT-CONTENTS is its initial content."
-  (cond
-   ((member-ignore-case field '("=type=" "crossref" "xref" "related"))
-    (error "[Ebib] Cannot edit `%s' field as multiline" field))
-   ((ebib-unbraced-p init-contents)
-    (error "[Ebib] Cannot edit a raw field as multiline"))
-   (t (ebib--multiline-edit (list 'field (ebib-db-get-filename ebib--cur-db) (ebib--get-key-at-point) field) (ebib-unbrace init-contents)))))
+FIELD is the field being edited.
 
-(defun ebib--edit-multiline-field (field)
-  "Edit FIELD in multiline-mode.
-
-Note: this function is essentially just a convenience wrapper
-over `ebib--edit-field-as-multiline'."
-  (let ((init-contents (ebib-get-field-value field (ebib--get-key-at-point) ebib--cur-db 'noerror)))
-    (ebib--edit-field-as-multiline field init-contents)))
+_FIELDS and _INIT-CONTENTS are ignored. They are included as
+arguments for compatibility with `ebib-field-edit-functions'."
+  (let ((init-contents
+	 (ebib-get-field-value field (ebib--get-key-at-point) ebib--cur-db 'noerror)))
+    (cond
+     ((member-ignore-case field '("=type=" "crossref" "xref" "related"))
+      (error "[Ebib] Cannot edit `%s' field as multiline" field))
+     ((ebib-unbraced-p init-contents)
+      (error "[Ebib] Cannot edit a raw field as multiline"))
+     (t (ebib--multiline-edit
+	 (list 'field (ebib-db-get-filename ebib--cur-db) (ebib--get-key-at-point) field)
+	 (ebib-unbrace init-contents))))))
 
 (defun ebib-edit-current-field-as-multiline ()
   "Edit current field in multiline-mode."
   (interactive)
-  (ebib--edit-multiline-field (ebib--current-field)))
+  (ebib--edit-field-as-multiline (ebib--current-field)))
 
 (defun ebib-insert-abbreviation (field)
   "Insert an abbreviation into FIELD from the ones defined in the database."

--- a/ebib.el
+++ b/ebib.el
@@ -4110,7 +4110,7 @@ special manner."
                    (ebib--edit-normal-field field init-contents))
 		  ((when-let ((data (assoc field ebib-field-edit-functions
 					   (lambda (a b) (member-ignore-case b a)))))
-		     (funcall (cdr data) field (car data) init-contents)))
+		     (funcall (cdr data) field (car data) (ebib-unbrace init-contents))))
                   ;; An external note is shown in the field "external note", but
                   ;; `ebib--current-field' only reads up to the first space, so
                   ;; it just returns "external".
@@ -4125,7 +4125,7 @@ special manner."
       ;; A numeric prefix argument is always non-nil when a command is called
       ;; interactively, so `pfx' can only be nil if `ebib-edit-field' is called
       ;; from Lisp code.
-      (ebib-set-field-value field result key ebib--cur-db)
+      (ebib-set-field-value field result key ebib--cur-db 'overwrite (ebib-unbraced-p init-contents))
       (when pfx (ebib-next-field))
       (ebib--redisplay-field field)
       (ebib--redisplay-index-item field))))

--- a/ebib.el
+++ b/ebib.el
@@ -4175,6 +4175,13 @@ Arguments are as in `ebib--edit-literal-field'."
     "slovene" "slovenian" "spanish" "swedish" "ukrainian")
   "List of language IDs used in BibLaTeX.")
 
+(defun ebib--edit-lang-id-field (field-name fields init-contents)
+  "Edit \"lang-id\" field.
+
+Arguments are as in `ebib--edit-literal-field'."
+  (ebib--edit-literal-field
+   field-name fields init-contents ebib--biblatex-language-keys))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4190,6 +4190,15 @@ Arguments are as in `ebib--edit-literal-field'."
    field-name fields init-contents
    '("page" "column" "line" "verse" "section" "paragraph")))
 
+(defun ebib--edit-pubstate-field (field-name fields init-contents)
+  "Edit \"pubstate\" field.
+
+Arguments are as in `ebib--edit-literal-field'."
+  (ebib--edit-literal-field
+   field-name fields init-contents
+   '("inpreparation" "submitted"
+     "forthcoming" "inpress" "prepublished")))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4215,6 +4215,15 @@ all selected keys are returned as a list of strings."
 	(mapcar #'car entry)
       (caar entry))))
 
+(defun ebib--edit-ref-field (field-name _ _)
+  "Edit an 'entry key' type field.
+FIELD-NAME is the name of the field being edited. Key is read
+with `ebib--read-ref-as-entry'.
+
+The other two argument places are for compatibility with
+`ebib-field-edit-functions', and are ignore."
+  (ebib--read-ref-as-entry (format "%s: " field-name) `(,ebib--cur-db)))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4042,34 +4042,28 @@ all other authors and editors in all databases."
   (seq-uniq (apply 'append (mapcar #'ebib--create-collection-from-field
 				   fields))))
 
-(defun ebib--edit-normal-field (field init-contents &optional complete)
+(defun ebib--edit-field-literally (field init-contents &optional complete)
   "Edit a field as a string.
 FIELD is the field being edited, INIT-CONTENTS is its initial
 contents.  If COMPLETE is non-nil, offer completion, the list of
 completion candidates being composed of the contents of FIELD in
 all entries of the database.  If COMPLETE is nil, just ask for a
-string in the minibuffer."
+string in the minibuffer.  Return the resulting string."
   (let* ((unbraced? nil)
          (key (ebib--get-key-at-point)))
     (when init-contents
       (setq unbraced? (ebib-unbraced-p init-contents))
       (setq init-contents (ebib-unbrace init-contents)))
-    (ebib--ifstring (new-contents (if complete
-                                      (let ((minibuffer-local-completion-map (make-composed-keymap '(keymap (32)) minibuffer-local-completion-map)))
-                                        (completing-read (format "%s: " field)
-                                                         (ebib--create-collection-from-field field)
-                                                         nil nil
-                                                         (if init-contents
-                                                             (cons init-contents 0))))
-                                    (read-string (format "%s: " field)
-                                                 (if init-contents
-                                                     (cons init-contents 0)))))
-        (ebib-set-field-value field new-contents key ebib--cur-db 'overwrite unbraced?)
-      (ebib-db-remove-field-value field key ebib--cur-db))
-    (ebib--redisplay-current-field)
-    (ebib--set-modified t ebib--cur-db t (seq-filter (lambda (dependent)
-                                                       (ebib-db-has-key key dependent))
-                                                     (ebib--list-dependents ebib--cur-db)))))
+    (if complete
+        (let ((minibuffer-local-completion-map (make-composed-keymap '(keymap (32)) minibuffer-local-completion-map)))
+          (completing-read (format "%s: " field)
+                           (ebib--create-collection-from-field field)
+                           nil nil
+                           (if init-contents
+                               (cons init-contents 0))))
+      (read-string (format "%s: " field)
+                   (if init-contents
+                       (cons init-contents 0))))))
 
 (defun ebib-edit-field (field)
   "Edit FIELD of a BibTeX entry.
@@ -4107,7 +4101,7 @@ special manner."
                   ;; a string, without any form of completion.  Evaluate `pfx' as
 		  ;; a cond.
                   (pfx
-                   (ebib--edit-normal-field field init-contents))
+                   (ebib--edit-field-literally field init-contents))
 		  ((when-let ((data (assoc field ebib-field-edit-functions
 					   (lambda (a b) (member-ignore-case b a)))))
 		     (funcall (cdr data) field (car data) (ebib-unbrace init-contents))))
@@ -4118,14 +4112,16 @@ special manner."
                    (ebib-popup-note (ebib--get-key-at-point))
                    nil) ; See above.
                   ;; The catch-all edits a field without completion.
-                  (t (ebib--edit-normal-field field init-contents)))))
+                  (t (ebib--edit-field-literally field init-contents)))))
     ;; When the edit returns, see if we need to move to the next field and
     ;; check whether we need to update the index display.
     (when result
+      (ebib--ifstring (val result)
+	  (ebib-set-field-value field val key ebib--cur-db 'overwrite (ebib-unbraced-p init-contents))
+	(ebib-db-remove-field-value field key ebib--cur-db))
       ;; A numeric prefix argument is always non-nil when a command is called
       ;; interactively, so `pfx' can only be nil if `ebib-edit-field' is called
       ;; from Lisp code.
-      (ebib-set-field-value field result key ebib--cur-db 'overwrite (ebib-unbraced-p init-contents))
       (when pfx (ebib-next-field))
       (ebib--redisplay-field field)
       (ebib--redisplay-index-item field)

--- a/ebib.el
+++ b/ebib.el
@@ -4182,6 +4182,14 @@ Arguments are as in `ebib--edit-literal-field'."
   (ebib--edit-literal-field
    field-name fields init-contents ebib--biblatex-language-keys))
 
+(defun ebib--edit-pagination-field (field-name fields init-contents)
+  "Edit \"pagination\" field.
+
+Arguments are as in `ebib--edit-literal-field'."
+  (ebib--edit-literal-field
+   field-name fields init-contents
+   '("page" "column" "line" "verse" "section" "paragraph")))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4156,6 +4156,51 @@ See also `ebib-field-edit-functions'."
    nil					;; require-match
    init-contents))                      ;; initial-input
 
+(defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
+  "Edit a 'name list' or 'literal list' type field.
+
+FIELD-NAME is the name of the field being edited. FIELDS is a
+list of fields from which to pull completion candidates.
+INIT-CONTENTS is the original value of the field. In name- and
+literal-list fields, this is an \"and\"-delimited list of values,
+as a single string.
+
+EXTRA-TABLES are extra completion tables to be included in the
+candidate list, alongside the candidates generated from FIELDS.
+This argument is useful for list fields which have a canonical
+list of candidates, like \"language\".
+
+See also `ebib-field-edit-functions'."
+  (let* ((crm-char ";")
+	 (crm-separator (format "[[:space:]]+*%s[[:space:]]+*" crm-char))
+	 (and-regexp "[[:space:]]+and[[:space:]]+")
+	 (collection
+	  ;; Account for fields containing more than one entry, e.g.
+	  ;; author = {Bar, Foo and Qux, Baz}
+	  (delete-dups
+	   (apply
+	    #'append
+	    (mapcar (lambda (str) (split-string str and-regexp t "[[:space:]]"))
+		    (ebib--create-collection-from-fields fields)))))
+	 (table (apply #'completion-table-merge `(,collection ,@extra-tables)))
+	 (result (completing-read-multiple
+		  (format "%s: " field-name)           ;; prompt
+		  table                                ;; collection
+		  (lambda (str) (not (string-empty-p str))) ;; predicate
+		  nil                                  ;; require-match
+		  ;; Replace all instances of " and " (Bib(La)TeX's
+		  ;; list separator) in initial contents with " ; "
+		  ;; (our list separator). Then append a crm-separator
+		  ;; to the result, so that `completing-read-multiple'
+		  ;; treats it as a list of selected candidates
+		  (when init-contents
+		    (concat
+		     (replace-regexp-in-string
+		      and-regexp (format " %s " crm-char)
+		      init-contents)
+		     crm-char)))))
+    (string-join result " and ")))
+
 (defun ebib-edit-current-field ()
   "Edit current field of a BibTeX entry.
 Most fields are edited directly using the minibuffer, but a few

--- a/ebib.el
+++ b/ebib.el
@@ -4164,6 +4164,17 @@ Arguments are as in `ebib--edit-literal-field'."
    '("editor" "compiler" "founder" "continuator"
      "redactor" "reviser" "collaborator" "organizer")))
 
+(defconst ebib--biblatex-language-keys
+  '("bulgarian" "catalan" "croatian" "czech" "danish" "dutch"
+    "american" "USenglish" "english" "british" "UKenglish"
+    "canadian" "australian" "newzealand" "estonian" "finnish"
+    "french" "german" "austrian" "swissgerman" "ngerman"
+    "naustrian" "nswissgerman" "greek" "magyar" "hungarian"
+    "icelandic" "italian" "latvian" "norsk" "nynorsk" "polish"
+    "brazil" "portuguese" "portuges" "russian" "slovak"
+    "slovene" "slovenian" "spanish" "swedish" "ukrainian")
+  "List of language IDs used in BibLaTeX.")
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4224,6 +4224,20 @@ The other two argument places are for compatibility with
 `ebib-field-edit-functions', and are ignore."
   (ebib--read-ref-as-entry (format "%s: " field-name) `(,ebib--cur-db)))
 
+(defun ebib--edit-ref-list-field (field-name _ _)
+  "Read multiple entry keys, returning a comma-separated list.
+
+FIELD-NAME is the name of the field being edited. Key is read
+with `ebib--read-ref-as-entry'.
+
+The other two argument places are for compatibility with
+`ebib-field-edit-functions', and are ignore."
+  (let ((list (ebib--read-ref-as-entry
+	       field-name `(,ebib--cur-db) 'multiple)))
+    ;; NOTE When used with BibLaTeX, this assumes that xsvsep is set to
+    ;; "\s*,\s*", equivalent to "[[:space:]]*,[[:space:]]" in Emacs.
+    (string-join list ", ")))
+
 (defun ebib--edit-list-field (field-name fields init-contents &optional &rest extra-tables)
   "Edit a 'name list' or 'literal list' type field.
 

--- a/ebib.el
+++ b/ebib.el
@@ -4118,9 +4118,10 @@ special manner."
     ;; When the edit returns, see if we need to move to the next field and
     ;; check whether we need to update the index display.
     (when result
-      (ebib--ifstring (val result)
-	  (ebib-set-field-value field val key ebib--cur-db 'overwrite (ebib-unbraced-p init-contents))
-	(ebib-db-remove-field-value field key ebib--cur-db))
+      (when (stringp result)
+	(ebib--ifstring (val result)
+	    (ebib-set-field-value field val key ebib--cur-db 'overwrite (ebib-unbraced-p init-contents))
+	  (ebib-db-remove-field-value field key ebib--cur-db)))
       ;; A numeric prefix argument is always non-nil when a command is called
       ;; interactively, so `pfx' can only be nil if `ebib-edit-field' is called
       ;; from Lisp code.

--- a/ebib.el
+++ b/ebib.el
@@ -4037,6 +4037,11 @@ all other authors and editors in all databases."
                                                                                    (not (ebib-db-dependent-p db)))
                                                                                  ebib--databases)))))))
 
+(defun ebib--create-collection-from-fields (fields)
+  "Create a collection from contents of a list of FIELDS."
+  (seq-uniq (apply 'append (mapcar #'ebib--create-collection-from-field
+				   fields))))
+
 (defun ebib--edit-normal-field (field init-contents &optional complete)
   "Edit a field as a string.
 FIELD is the field being edited, INIT-CONTENTS is its initial

--- a/ebib.el
+++ b/ebib.el
@@ -4267,6 +4267,34 @@ Arguments are as in `ebib--edit-list-field'."
    field-name fields init-contents
    ebib--biblatex-language-keys))
 
+(defun ebib--edit-separated-values-field (field-name fields init-contents)
+  "Edit a 'separated values' type field.
+FIELD-NAME is the name of the field being edited. FIELDS is a
+list of fields from which to pull completion candidates.
+INIT-CONTENTS is the original value of the field, assumed to be a
+list separated by commas with optional whitespace on either side.
+
+See also `ebib-field-edit-functions'."
+  ;; NOTE When used with BibLaTeX, this assumes that xsvsep is set to
+  ;; "\s*,\s*", equivalent to "[[:space:]]*,[[:space:]]" in Emacs.
+  (let* ((crm-separator "[[:space:]]*,[[:space:]]*")
+	 (collection
+	  ;; Account for fields containing more than one entry, e.g.
+	  ;; keywords = {Bar, Foo, Qux}
+	  (delete-dups
+	   (apply
+	    #'append
+	    (mapcar (lambda (str)
+		      (split-string str crm-separator t "[[:space:]]"))
+		    (ebib--create-collection-from-fields fields)))))
+	 (result (completing-read-multiple
+		  (format "%s: " field-name) collection nil nil
+		  ;; Append a crm-separator to the result, so that
+		  ;; `completing-read-multiple' treats it as a list of
+		  ;; selected candidates
+		  (when init-contents (concat init-contents ", ")))))
+    (string-join result ", ")))
+
 (defun ebib-edit-current-field ()
   "Edit current field of a BibTeX entry.
 Most fields are edited directly using the minibuffer, but a few


### PR DESCRIPTION
The code for editing these fields at the moment produces an experience similar enough to `completing-read-multiple` that I expect them to work that way (and integrate with things like vertico) but different enought that it's annoying and jarring when they don't. I think it would be fairly simple to use `completing-read-multiple` in the code and get all the features currently available in these fields. If anything, I think using it might even simplify the code. Here's a version of file-name completion for editting the file field which seems to work pretty well:

```elisp
(defun ebib--edit-file-field ()
  "Edit the \"file\" field'.
Filenames are added to the standard file field separated by
`ebib-filename-separator'.  The first directory in
`ebib-file-search-dirs' is used as the start directory.  If
`ebib-truncate-file-names' is t, file names are truncated
relative to the directories listed in `ebib-file-search-dirs',
otherwise they are stored as absolute paths."
  (let* ((default-directory (file-name-as-directory (car ebib-file-search-dirs)))
         (key (ebib--get-key-at-point))
	 (init-conts (ebib-get-field-value "file" key ebib--cur-db 'noerror 'unbraced))
	 (crm-separator ebib-filename-separator)
	 (new-file-list (completing-read-multiple
			 "Add file(s): " ;; prompt
			 'completion-file-name-table ;; completions
			 'file-regular-p ;; predicate (only show files)
			 t		 ;; require match
			 ;; Make sure that the initial contents end in
			 ;; a crm-separator, so that even when there
			 ;; is only one, `completing-read-mutiple'
			 ;; realises that it is a completion candidate
			 ;; and not an input string
			 (concat init-conts crm-separator))) ;; init-contents
	 (trunc-file-list (mapcar 'ebib--transform-file-name-for-storing new-file-list))
	 (new-conts (string-join trunc-file-list ebib-filename-separator)))
    (ebib-set-field-value "file" new-conts key ebib--cur-db 'overwrite)
    (ebib--redisplay-current-field)
    (ebib--set-modified t ebib--cur-db t (seq-filter (lambda (dependent)
                                                       (ebib-db-has-key key dependent))
                                                     (ebib--list-dependents ebib--cur-db)))
    ;; Return t if the field was modified.
    (ebib-db-modified-p ebib--cur-db)))
```

Obviously, this also makes life *much* nicer for people like me who use extensions which alter the behaviour of `completing-read-(multiple)`. I use vertico and the experience of editting entries with multiple files is *much* better with the above code.

If you think this is a good idea, I think I could cover the editting functions for all the fields which have completion like this pretty quickly, and sumbit a PR.

(edit to add: another benefit of this with files is that using `completion-file-name-table` sets the completion category correctly, so that users of marginalia will get proper file metadata. Overhauling the completion for the other fields could include setting this up for them too, which would make it (much) easier to write a marginalia extension for ebib at some point)