### PR TITLE
Make crossref fields clickable (like `file`, `doi`, etc.)

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -466,7 +466,9 @@ which can be passed to `ebib--display-multiline-field'."
       (if (cl-equalp field "url")
           (setq value (ebib--display-url-field value)))
       (if (cl-equalp field "doi")
-          (setq value (ebib--display-doi-field value))))
+          (setq value (ebib--display-doi-field value)))
+      (if (cl-equalp field "crossref")
+          (setq value (ebib--display-crossref-field value))))
     (concat raw value alias multiline)))
 
 (defun ebib--display-fields (key &optional db match-str)

--- a/ebib.el
+++ b/ebib.el
@@ -4204,10 +4204,14 @@ viewed."
                         (get-text-property 0 'ebib-file word)))
              (url (and word
                        (get-text-property 0 'mouse-face word)
-                       (get-text-property 0 'ebib-url word))))
+                       (get-text-property 0 'ebib-url word)))
+	     (crossref (and word
+                       (get-text-property 0 'mouse-face word)
+                       (get-text-property 0 'ebib-crossref word))))
         (cond
          (file (ebib--call-file-viewer file))
-         (url (ebib--call-browser url))))
+         (url (ebib--call-browser url))
+	 (crossref (ebib-follow-crossref))))
     ;; Properly position the cursor.
     (beginning-of-line)
     (let ((direction (alist-get (ebib--line-at-point)

--- a/ebib.el
+++ b/ebib.el
@@ -334,6 +334,14 @@ of strings."
                                                              'ebib-url url))
                                                urls))))
 
+(defun ebib--display-crossref-field (crossref)
+  "Return a string for CROSSREF to display in the entry buffer."
+  (propertize crossref
+              'face '(:inherit ebib-link-face)
+              'mouse-face '(highlight (:inherit ebib-link-face))
+              'help-echo "mouse-1: follow crossref"
+              'ebib-crossref t))
+
 (defun ebib--extract-note-text (key &optional truncate)
   "Extract the text of the note for entry KEY.
 

--- a/ebib.el
+++ b/ebib.el
@@ -2875,10 +2875,14 @@ new database."
                     (get-text-property 0 'help-echo word)))
          (notep (and word
                      (get-text-property 0 'mouse-face word)
-                     (string-equal word ebib-notes-symbol))))
+                     (string-equal word ebib-notes-symbol)))
+	 (crossref (and word
+                       (get-text-property 0 'mouse-face word)
+                       (get-text-property 0 'ebib-crossref word))))
     (cond
      (link (ebib--call-browser link))
      (notep (ebib-popup-note (ebib--get-key-at-point)))
+     (crossref (ebib-follow-crossref))
      (t (when (eobp)
           (forward-line -1))
         (ebib-select-and-popup-entry)))))


### PR DESCRIPTION
Just thought this might be fun. I wanted crossref fields to be clickable, to open the relevant entry, after the fashion of `file`, `doi` etc. I followed the pattern used for those fields in my implementation.

I've got a couple of questions though:
- first, why is the functionality for clickability implemented with an ebib-specific mechanism (`ebib-index-open-at-point` and `ebib-entry-open-at-point`) rather than with the standard Emacs `button` libary and functions? I've used Emacs buttons a lot in my own display functions for the index buffer and they work great, but the ebib-specific stuff initially confused me.
- second, is there a reason there are separate functions for opening-at-point in the index and entry buffers?