### PR TITLE
Use button functionality to make some fields clickable (now including `crossref`)

### DIFF
--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -419,7 +419,15 @@ string of the same width as `ebib-notes-symbol'."
   (if (ebib--notes-has-note key)
       (propertize ebib-notes-symbol
                   'face '(:height 0.8 :inherit ebib-link-face)
-                  'mouse-face 'highlight)
+		  'font-lock-face '(:height 0.8 :inherit ebib-link-face)
+                  'mouse-face 'highlight
+		  'help-echo "mouse-1: popup note"
+		  'button t
+		  'follow-link t
+		  'category t
+		  'button-data key
+		  'keymap button-map
+		  'action 'ebib-popup-note)
     (propertize (make-string (string-width ebib-notes-symbol) ?\s)
                 'face '(:height 0.8))))
 

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -2387,14 +2387,23 @@ are returned as a string."
 (defun ebib-display-www-link (field key db)
   "Return the content of FIELD from KEY in DB as a link.
 This function is mainly intended for the DOI and URL fields."
-  (let ((str (ebib-get-field-value field key db 'noerror 'unbraced 'xref)))
-    (if (and str (string-match-p "^[0-9]" str))
-        (setq str (concat "https://dx.doi.org/" str)))
-    (if str
-        (propertize "www"
-                    'face '(:height 0.8 :inherit ebib-link-face)
-                    'mouse-face 'highlight
-                    'help-echo str)
+  (let* ((val (ebib-get-field-value field key db 'noerror 'unbraced 'xref))
+	 ;; Unless field is doi, assume the string is a full url
+	 (str (if (and (string= (downcase field) "doi")
+		       (string-match-p "^[0-9]" val))
+		  (concat "https://dx.doi.org/" val)
+		val)))
+    (if val (propertize "www"
+			'face 'button
+			'font-lock-face 'button
+			'mouse-face 'highlight
+			'help-echo str
+			'button t
+			'follow-link t
+			'category t
+			'button-data str
+			'keymap button-map
+			'action 'ebib--call-browser)
       (propertize "   " 'face '(:height 0.8)))))
 
 (defun ebib--sort-keys-list (keys db)

--- a/ebib.el
+++ b/ebib.el
@@ -325,10 +325,16 @@ of strings."
 (defun ebib--display-doi-field (doi-field)
   "Return a string for DOI-FIELD to display in the entry buffer."
   (propertize doi-field
-              'face '(:inherit ebib-link-face)
-              'mouse-face '(highlight (:inherit ebib-link-face))
-              'help-echo "mouse-1: follow this doi"
-              'ebib-url (concat "https://dx.doi.org/" doi-field)))
+	      'face 'button
+	      'font-lock-face 'button
+	      'mouse-face 'highlight
+	      'help-echo "mouse-1: follow this doi"
+	      'button t
+	      'follow-link t
+	      'category t
+	      'button-data (concat "https://dx.doi.org/" doi-field)
+	      'keymap button-map
+	      'action 'ebib--call-browser))
 
 (defun ebib--display-url-field (url-field)
   "Return a string for URL-FIELD to display in the entry buffer."

--- a/ebib.el
+++ b/ebib.el
@@ -492,7 +492,9 @@ which can be passed to `ebib--display-multiline-field'."
       (if (cl-equalp field "url")
           (setq value (ebib--display-url-field value)))
       (if (cl-equalp field "doi")
-          (setq value (ebib--display-doi-field value))))
+          (setq value (ebib--display-doi-field value)))
+      (if (cl-equalp field "crossref")
+          (setq value (ebib--display-crossref-field value))))
     (concat raw value alias multiline)))
 
 (defun ebib--display-fields (key &optional db match-str)

--- a/ebib.el
+++ b/ebib.el
@@ -339,13 +339,20 @@ of strings."
 (defun ebib--display-url-field (url-field)
   "Return a string for URL-FIELD to display in the entry buffer."
   (let ((urls (ebib--split-urls url-field)))
-    (ebib--convert-multiline-to-string (mapcar (lambda (url)
-                                                 (propertize url
-                                                             'face '(:inherit ebib-link-face)
-                                                             'mouse-face '(highlight (:inherit ebib-link-face))
-                                                             'help-echo "mouse-1: follow this url"
-                                                             'ebib-url url))
-                                               urls))))
+    (ebib--convert-multiline-to-string
+     (mapcar (lambda (url)
+	       (propertize url
+			   'face 'button
+			   'font-lock-face 'button
+			   'mouse-face 'highlight
+			   'help-echo "mouse-1: follow this url"
+			   'button t
+			   'follow-link t
+			   'category t
+			   'button-data url
+			   'keymap button-map
+			   'action 'ebib--call-browser))
+             urls))))
 
 (defun ebib--extract-note-text (key &optional truncate)
   "Extract the text of the note for entry KEY.

--- a/ebib.el
+++ b/ebib.el
@@ -1067,7 +1067,6 @@ keywords before Emacs is killed."
     (define-key map "y" #'ebib-yank-entry)
     (define-key map "z" #'ebib-leave-ebib-windows)
     (define-key map "Z" #'ebib-lower)
-    (define-key map [mouse-1] #'ebib-index-open-at-point)
     map)
   "Keymap for the ebib index buffer.")
 
@@ -2891,23 +2890,6 @@ new database."
        (when arg
          (ebib-db-set-current-entry-key nil ebib--cur-db))
        (ebib--update-buffers 'no-refresh)))))
-
-(defun ebib-index-open-at-point ()
-  "Open link, note or files at point."
-  (interactive)
-  (let* ((word (thing-at-point 'word))
-         (link (and word
-                    (get-text-property 0 'mouse-face word)
-                    (get-text-property 0 'help-echo word)))
-         (notep (and word
-                     (get-text-property 0 'mouse-face word)
-                     (string-equal word ebib-notes-symbol))))
-    (cond
-     (link (ebib--call-browser link))
-     (notep (ebib-popup-note (ebib--get-key-at-point)))
-     (t (when (eobp)
-          (forward-line -1))
-        (ebib-select-and-popup-entry)))))
 
 (defun ebib-browse-url (&optional arg)
   "Browse the URL in the \"url\" field.

--- a/ebib.el
+++ b/ebib.el
@@ -354,6 +354,20 @@ of strings."
 			   'action 'ebib--call-browser))
              urls))))
 
+(defun ebib--display-crossref-field (crossref)
+  "Return a string for CROSSREF to display in the entry buffer."
+  (propertize crossref
+	      'face 'button
+	      'font-lock-face 'button
+	      'mouse-face 'highlight
+	      'help-echo "mouse-1: follow crossref"
+	      'button t
+	      'follow-link t
+	      'category t
+	      'button-data nil
+	      'keymap button-map
+	      'action (lambda (_) (ebib-follow-crossref))))
+
 (defun ebib--extract-note-text (key &optional truncate)
   "Extract the text of the note for entry KEY.
 

--- a/ebib.el
+++ b/ebib.el
@@ -3681,7 +3681,6 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "\C-xb" 'ebib-quit-entry-buffer)
     (define-key map "\C-xk" 'ebib-quit-entry-buffer)
     (define-key map "\C-x\C-s" #'ebib-save-current-database)
-    (define-key map [mouse-1] #'ebib-entry-open-at-point)
     map)
   "Keymap for the Ebib entry buffer.")
 
@@ -4183,30 +4182,6 @@ viewed."
   (let ((file (ebib-get-field-value (ebib--current-field) (ebib--get-key-at-point) ebib--cur-db 'noerror 'unbraced 'xref))
         (num (if (numberp arg) arg nil)))
     (ebib--call-file-viewer (ebib--select-file file num (ebib--get-key-at-point)))))
-
-(defun ebib-entry-open-at-point ()
-  "Open file at point."
-  (interactive)
-  (unwind-protect
-      (let* ((word (thing-at-point 'word))
-             (file (and word
-                        (get-text-property 0 'mouse-face word)
-                        (get-text-property 0 'ebib-file word)))
-             (url (and word
-                       (get-text-property 0 'mouse-face word)
-                       (get-text-property 0 'ebib-url word))))
-        (cond
-         (file (ebib--call-file-viewer file))
-         (url (ebib--call-browser url))))
-    ;; Properly position the cursor.
-    (beginning-of-line)
-    (let ((direction (alist-get (ebib--line-at-point)
-                                '((last-line . -1) ; Move up.
-                                  (multi-line . -1)
-                                  (empty-line . 1))))) ; Move down.
-      (when direction
-        (while (ebib--line-at-point)
-          (forward-line direction))))))
 
 (defun ebib-copy-field-contents (field)
   "Copy the contents of FIELD to the kill ring.

--- a/ebib.el
+++ b/ebib.el
@@ -58,6 +58,7 @@
 (require 'hl-line)
 (require 'mule-util)
 (require 'parsebib)
+(require 'button)
 (require 'ebib-utils)
 (require 'ebib-db)
 (require 'ebib-filters)
@@ -308,11 +309,17 @@ of strings."
   "Return a string for FILE-FIELD to display in the entry buffer."
   (let ((files (ebib--split-files file-field)))
     (ebib--convert-multiline-to-string (mapcar (lambda (file)
-                                                 (propertize file
-                                                             'face '(:inherit ebib-link-face)
-                                                             'mouse-face '(highlight (:inherit ebib-link-face))
-                                                             'help-echo "mouse-1: open this file"
-                                                             'ebib-file file))
+						 (propertize file
+							     'face 'button
+							     'font-lock-face 'button
+							     'mouse-face 'highlight
+							     'help-echo "mouse-1: open this file"
+							     'button t
+							     'follow-link t
+							     'category t
+							     'button-data file
+							     'keymap button-map
+							     'action 'ebib--call-file-viewer))
                                                files))))
 
 (defun ebib--display-doi-field (doi-field)


### PR DESCRIPTION
Replaces #264.

Use Emacs-standard button library to make some text clickable, replacing the previous mechanism. Reasons are given in the commit messages and #264. Make `crossref` fields clickable, to follow the crossref (similar to opening a file).