### PR TITLE
Commands to support other navigation paradigms

### DIFF
--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -45,7 +45,7 @@
 (require 'ebib)
 (require 'citar)
 
-(defun ebib-citar-backend (operation args)
+(defun ebib-citar-backend (operation &rest args)
   "Citar backend for ebib notes.
 Execute OPERATION given ARGS per `ebib-notes-storage', which see."
   (pcase operation

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -45,13 +45,17 @@
 (require 'ebib)
 (require 'citar)
 
+(defvar ebib-citar--notes-checker nil
+  "Notes checker for ebib-citar.")
+
 (defun ebib-citar-backend (operation &rest args)
   "Citar backend for ebib notes.
 Execute OPERATION given ARGS per `ebib-notes-storage', which see."
   (pcase operation
     (`:has-note
-     (let ((has-notes-p (citar-has-notes)))
-       (if has-notes-p (funcall has-notes-p (car args)))))
+     (unless ebib-citar--notes-checker
+       (setf ebib-citar--notes-checker (citar-has-notes)))
+     (funcall ebib-citar--notes-checker (car args)))
     (`:create-note
      (citar-create-note (car args))
      (ebib-citar-backend :open-note (list (car args))))

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -47,7 +47,6 @@
 
 (defun ebib-citar-backend (operation args)
   "Citar backend for ebib notes.
-
 Execute OPERATION given ARGS per `ebib-notes-storage', which see."
   (pcase operation
     (`:has-note
@@ -66,20 +65,15 @@ Execute OPERATION given ARGS per `ebib-notes-storage', which see."
 
 (defvar ebib--citar-previous-values nil
   "Ebib-Citar integration variable backup.
-
-Will contain, as a list, the values of the following before
-`ebib-citar-mode' is enabled.
+When `ebib-citar-mode' is enabled, this variable is used to
+backup the values of the following variables:
  - `ebib-notes-storage'
  - `citar-open-entry-function'")
 
 (define-minor-mode ebib-citar-mode
   "Integrate Ebib and Citar.
-
-When enabled, `ebib-notes-storage' will be set to
-`ebib-citar-backend', and `citar-open-entry-function' will be set
-to `ebib-citar-entry-function'.  Thus, Citar will be used to
-manage notes, and Ebib will be used to open bibliographic
-entries."
+When enabled, use Citar to manage notes and Ebib to open
+bibliographic entries."
   :global t
   (if ebib-citar-mode
       (setf ebib--citar-previous-values (list ebib-notes-storage citar-open-entry-function)

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -32,7 +32,7 @@
 ;;; Commentary:
 
 ;; This file is part of Ebib, a BibTeX database manager for Emacs.  It
-;; contains functions that integrate [citar.el] with Ebib.
+;; contains functions that integrate [citar] with Ebib.
 ;;
 ;; [citar]: https://github.com/emacs-citar/citar
 ;;

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -50,7 +50,8 @@
 Execute OPERATION given ARGS per `ebib-notes-storage', which see."
   (pcase operation
     (`:has-note
-     (citar-has-notes (car args)))
+     (let ((has-notes-p (citar-has-notes)))
+       (funcall has-notes-p (car args))))
     (`:create-note
      (citar-create-note (car args))
      (ebib-citar-backend :open-note (list (car args))))

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -75,6 +75,7 @@ backup the values of the following variables:
 When enabled, use Citar to manage notes and Ebib to open
 bibliographic entries."
   :global t
+  :group 'ebib-notes
   (if ebib-citar-mode
       (setf ebib--citar-previous-values (list ebib-notes-storage citar-open-entry-function)
             ebib-notes-storage #'ebib-citar-backend

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -56,7 +56,7 @@ Execute OPERATION given ARGS per `ebib-notes-storage', which see."
      (citar-create-note (car args))
      (ebib-citar-backend :open-note (list (car args))))
     (`:open-note
-     (when-let* ((notes-file (car (last (citar-ebib-backend :has-note args))))
+     (when-let* ((notes-file (car (last (apply #'ebib-citar-backend :has-note args))))
                  (buffer (find-file-noselect notes-file)))
        buffer))))
 

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -1,0 +1,94 @@
+;;; ebib-citar.el --- Ebib Notes from Citar          -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Samuel W. Flint
+;; All rights reserved.
+
+;; Author: Samuel W. Flint <me@samuelwflint.com>
+;; Maintainer: Samuel W. Flint <me@samuelwflint.com>
+
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright
+;;    notice, this list of conditions and the following disclaimer.
+;; 2. Redistributions in binary form must reproduce the above copyright
+;;    notice, this list of conditions and the following disclaimer in the
+;;    documentation and/or other materials provided with the distribution.
+;; 3. The name of the author may not be used to endorse or promote products
+;;    derived from this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES ; LOSS OF USE,
+;; DATA, OR PROFITS ; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+;;; Commentary:
+
+;; This file is part of Ebib, a BibTeX database manager for Emacs.  It
+;; contains functions that integrate [citar.el] with Ebib.
+;;
+;; [citar]: https://github.com/emacs-citar/citar
+;;
+;; To use this code, `require' it in your init file, and enable
+;; `ebib-citar-mode'.  This mode will use `citar' to manage notes, and
+;; set `citar-open-entry-function' to open entries in Ebib.
+
+;;; Code:
+
+(require 'ebib)
+(require 'citar)
+
+(defun ebib-citar-backend (operation args)
+  "Citar backend for ebib notes.
+
+Execute OPERATION given ARGS per `ebib-notes-storage', which see."
+  (pcase operation
+    (`:has-note
+     (citar-has-notes (car args)))
+    (`:create-note
+     (citar-create-note (car args))
+     (ebib-citar-backend :open-note (list (car args))))
+    (`:open-note
+     (when-let* ((notes-file (car (last (citar-ebib-backend :has-note args))))
+                 (buffer (find-file-noselect notes-file)))
+       buffer))))
+
+(defun ebib-citar-entry-function (citekey)
+  "Open CITEKEY using `ebib'."
+  (ebib nil citekey))
+
+(defvar ebib-citar--previous-values nil
+  "Ebib-Citar integration variable backup.
+
+Will contain, as a list, the values of the following before
+`ebib-citar-mode' is enabled.
+ - `ebib-notes-storage'
+ - `citar-open-entry-function'")
+
+(define-minor-mode ebib-citar-mode
+  "Integrate Ebib and Citar.
+
+When enabled, `ebib-notes-storage' will be set to
+`ebib-citar-backend', and `citar-open-entry-function' will be set
+to `ebib-citar-entry-function'.  Thus, Citar will be used to
+manage notes, and Ebib will be used to open bibliographic
+entries."
+  :global t
+  (if ebib-citar-mode
+      (setf ebib-citar--previous-values (list ebib-notes-storage citar-open-entry-function)
+            ebib-notes-storage #'ebib-citar-backend
+            citar-open-entry-function #'ebib-citar-entry-function)
+    (setf ebib-notes-storage (nth 0 ebib-citar--previous-values)
+          citar-open-entry-function (nth 1 ebib-citar--previous-values)
+          ebib-citar--previous-values nil)))
+
+(provide 'ebib-citar)
+
+;;; ebib-citar.el ends here

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -64,7 +64,7 @@ Execute OPERATION given ARGS per `ebib-notes-storage', which see."
   "Open CITEKEY using `ebib'."
   (ebib nil citekey))
 
-(defvar ebib-citar--previous-values nil
+(defvar ebib--citar-previous-values nil
   "Ebib-Citar integration variable backup.
 
 Will contain, as a list, the values of the following before
@@ -82,12 +82,12 @@ manage notes, and Ebib will be used to open bibliographic
 entries."
   :global t
   (if ebib-citar-mode
-      (setf ebib-citar--previous-values (list ebib-notes-storage citar-open-entry-function)
+      (setf ebib--citar-previous-values (list ebib-notes-storage citar-open-entry-function)
             ebib-notes-storage #'ebib-citar-backend
             citar-open-entry-function #'ebib-citar-entry-function)
-    (setf ebib-notes-storage (nth 0 ebib-citar--previous-values)
-          citar-open-entry-function (nth 1 ebib-citar--previous-values)
-          ebib-citar--previous-values nil)))
+    (setf ebib-notes-storage (nth 0 ebib--citar-previous-values)
+          citar-open-entry-function (nth 1 ebib--citar-previous-values)
+          ebib--citar-previous-values nil)))
 
 (provide 'ebib-citar)
 

--- a/ebib-citar.el
+++ b/ebib-citar.el
@@ -60,7 +60,10 @@ Execute OPERATION given ARGS per `ebib-notes-storage', which see."
      (citar-create-note (car args))
      (ebib-citar-backend :open-note (list (car args))))
     (`:open-note
-     (when-let* ((notes-file (car (last (apply #'ebib-citar-backend :has-note args))))
+     (when-let* ((citekey (car args))
+                 (notes-hash-table (citar-get-notes citekey))
+                 (notes-files (gethash citekey notes-hash-table))
+                 (notes-file (nth (1- (length notes-files)) notes-files))
                  (buffer (find-file-noselect notes-file)))
        buffer))))
 

--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -84,7 +84,8 @@ vary based on ACTION.  The following keywords must be supported:
   :group 'ebib-notes
   :type '(choice (const :tag "Use one file per note" one-file-per-note)
                  (const :tag "Use multiple notes per file" multiple-notes-per-file)
-                 (function :tag "Use external library" ignore)))
+                 (const :tag "Use Citar" :value ebib-citar-backend)
+                 (function :tag "Use external library")))
 
 (defcustom ebib-notes-directory nil
   "Directory to save notes files to.

--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -66,10 +66,11 @@ If this option is set to `multiple-notes-per-file', notes are
 searched in the files and directories listed in
 `ebib-notes-locations'.
 
-If this option is set to a function, it must be a function of two
-arguments, ACTION and PARAMETERS.  ACTION is a keyword indicating
-what action to perform, PARAMETERS is a list of parameters, which
-vary based on ACTION.  The following keywords must be supported:
+If this option is set to a function, it must be a function of the
+following form: (ACTION &rest PARAMETERS).  ACTION is a keyword
+indicating what action to perform, and PARAMETERS is a list of
+parameters, which vary based on ACTION.  The following keywords
+must be supported:
 
  - `:has-note' takes a KEY, and returns non-nil if a note exists
    for the entry.
@@ -363,7 +364,7 @@ note file if `ebib-notes-storage' is set to `one-note-per-file'."
         (if (file-readable-p (ebib--create-notes-file-name key))
             (cl-pushnew key ebib--notes-list)))
        ((functionp ebib-notes-storage)
-        (funcall ebib-notes-storage :has-note (list key))))))
+        (apply ebib-notes-storage :has-note (list key))))))
 
 (defun ebib--notes-goto-note (key)
   "Find or create a buffer containing the note for KEY.
@@ -398,7 +399,7 @@ If KEY has no note, return nil."
                       (ebib--notes-open-single-note-file filename)))))
       (when buf (cons buf (with-current-buffer buf (point))))))
    ((functionp ebib-notes-storage)
-    (let ((buffer (funcall ebib-notes-storage :open-note (list key))))
+    (let ((buffer (apply ebib-notes-storage :open-note (list key))))
       (when buffer
         (cons buffer (with-current-buffer buffer (point))))))))
 
@@ -432,7 +433,7 @@ the position where point should be placed."
                     pos 1)
             (error "[Ebib] Could not create note file `%s' " filename))))
        ((functionp ebib-notes-storage)
-        (let ((note-data (funcall ebib-notes-storage :create-note (list key db))))
+        (let ((note-data (apply ebib-notes-storage :create-note (list key db))))
           (setq buf (car note-data)
                 pos (or (cdr note-data) 1)))))
       (let ((note (ebib--notes-fill-template key db)))

--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -66,20 +66,20 @@ If this option is set to `multiple-notes-per-file', notes are
 searched in the files and directories listed in
 `ebib-notes-locations'.
 
-If this option is set to a function, it must conform to the
-following specification.  It shall take two arguments, ACTION and
-PARAMETERS (a list as specified by ACTION).  Actions are as
-follows:
+If this option is set to a function, it must be a function of two
+arguments, ACTION and PARAMETERS.  ACTION is a keyword indicating
+what action to perform, PARAMETERS is a list of parameters, which
+vary based on ACTION.  The following keywords must be supported:
 
- - `:has-note' takes a KEY, and return a generalized boolean
-   determining if a note exists for the entry.
+ - `:has-note' takes a KEY, and returns non-nil if a note exists
+   for the entry.
 
- - `:create-note' takes a KEY and a DATABASE, returning a cons
+ - `:create-note' takes a KEY and a DATABASE and returns a cons
    of (BUFFER . POINT) where the note begins.  Depending on how
    note creation is performed, it may be helpful to set
    `ebib-notes-template' to the empty string.
 
- - `:open-note' takes a KEY and return a buffer, with point at
+ - `:open-note' takes a KEY and returns a buffer, with point at
    the start of the note."
   :group 'ebib-notes
   :type '(choice (const :tag "Use one file per note" one-file-per-note)

--- a/ebib-notes.el
+++ b/ebib-notes.el
@@ -84,7 +84,7 @@ vary based on ACTION.  The following keywords must be supported:
   :group 'ebib-notes
   :type '(choice (const :tag "Use one file per note" one-file-per-note)
                  (const :tag "Use multiple notes per file" multiple-notes-per-file)
-                 (const :tag "Use Citar" :value ebib-citar-backend)
+                 (function-item :tag "Use Citar" ebib-citar-backend)
                  (function :tag "Use external library")))
 
 (defcustom ebib-notes-directory nil

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -356,6 +356,23 @@ default sort field is visible in the index buffer."
                        (choice (const :tag "Ascending Sort" ascend)
                                (const :tag "Descending Sort" descend)))))
 
+(defun ebib--history-mutate (key)
+  "Alter `ebib--entry-history' list.
+Copy everything from the second element to the element at
+`ebib--history-get-head' in the `:history' list in
+`ebib--entry-history', reverse the result, and prepend it to the
+history list. Then prepend KEY to the history list as well.
+Finally, set `:head' in `ebib--entry-history' to 0."
+  (when-let ((head (ebib--history-get-head))
+	     ;; Only bother if head is sufficiently large, otherwise
+	     ;; there's nothing to prependQ
+	     (_ (< 1 head))
+	     (hist-list (plist-get ebib--entry-history :history))
+	     (interim (seq-subseq hist-list 0 head)))
+    (plist-put ebib--entry-history :history
+	       (append (reverse interim) hist-list)))
+  (push key (plist-get ebib--entry-history :history))
+  (ebib--history-set-head 0))
 
 (defun ebib--history-get (n)
   "Get Nth elt of `:history' list in `ebib--entry-history'.

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -365,6 +365,13 @@ return nil.."
     (nth n (plist-get ebib--entry-history :history))))
 
 (defun ebib--history-set-head (n)
+  "Set `:head' in `ebib--entry-history' to N."
+  (plist-put ebib--entry-history :head n))
+
+(defun ebib--history-get-head ()
+  "Get value of `:head' in `ebib--entry-history'."
+  (plist-get ebib--entry-history :head))
+
 (defun ebib-compare-numerical-strings (a b)
   "Return t if A represents a number less than B represents.
 A and B are strings (e.g. \"3\" and \"11\")."

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -356,6 +356,15 @@ default sort field is visible in the index buffer."
                        (choice (const :tag "Ascending Sort" ascend)
                                (const :tag "Descending Sort" descend)))))
 
+
+(defun ebib--history-get (n)
+  "Get Nth elt of `:history' list in `ebib--entry-history'.
+N counts from 0. If N < 0, or there are not enough elements,
+return nil.."
+  (when (>= n 0)
+    (nth n (plist-get ebib--entry-history :history))))
+
+(defun ebib--history-set-head (n)
 (defun ebib-compare-numerical-strings (a b)
   "Return t if A represents a number less than B represents.
 A and B are strings (e.g. \"3\" and \"11\")."

--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -1287,6 +1287,23 @@ Currently, the following problems are marked:
 (defvar ebib--citation-history nil "Minibuffer history for citation commands.")
 (defvar ebib--key-history nil "Minibuffer history for entry keys.")
 (defvar ebib--keywords-history nil "Minibuffer history for keywords.")
+(defvar ebib--entry-history '(:head 0 :history nil)
+  "History of entries visited.
+`:history' is a list of all entries visited, with more recent
+entries nearer the beginning. `:head' is a 0-based index
+indicating where in the `:history' list we are currently.
+
+Commands which navigate between entries (including those which
+navigate the history) should (in order):
+- Copy everything from the second to the `:head'th element of the
+  `:history' list, reverse the result, and prepend it to the history
+  list (unless the `:head' value is less than 2, in which case nothing
+  would be prepended).
+- prepend the key of the entry arrived at to the `:history' list.
+- set `:head' to 0
+
+Passing the relevant key to `ebib--history-mutate' will achieve
+all of this in a convenient way.")
 
 (defvar ebib--saved-window-config nil "Stores the window configuration when Ebib is called.")
 (defvar ebib--window-before nil "The window that was active when Ebib was called.")

--- a/ebib.el
+++ b/ebib.el
@@ -2409,6 +2409,18 @@ Interactively, prompt for REGISTER with
   (interactive `(,(register-read-with-preview "Entry to register: ")))
   (set-register register (ebib--get-key-at-point)))
 
+(defun ebib-jump-to-register (register)
+  "Jump to entry with key stored in REGISTER.
+Interactively, prompt for REGISTER with
+`register-read-with-preview'."
+  (interactive `(,(register-read-with-preview "Jump to register: ")))
+  (let* ((key (get-register register))
+	 (db (ebib--find-db-for-key key ebib--cur-db)))
+    (if (not (ebib-db-has-key key db))
+	(error "[Ebib] Could not find entry key `%s'" key)
+      (ebib--goto-entry-in-index key)
+      (ebib--update-entry-buffer))))
+
 (defun ebib-jump-to-entry (arg)
   "Jump to an entry.
 Select an entry from any open database using completion and jump

--- a/ebib.el
+++ b/ebib.el
@@ -2402,6 +2402,13 @@ buffer and switch to it."
     (default
       (beep))))
 
+(defun ebib-current-entry-to-register (register)
+  "Store current entry's key as a string in REGISTER.
+Interactively, prompt for REGISTER with
+`register-read-with-preview'."
+  (interactive `(,(register-read-with-preview "Entry to register: ")))
+  (set-register register (ebib--get-key-at-point)))
+
 (defun ebib-jump-to-entry (arg)
   "Jump to an entry.
 Select an entry from any open database using completion and jump

--- a/ebib.el
+++ b/ebib.el
@@ -3902,6 +3902,8 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "\C-x\C-s" #'ebib-save-current-database)
     (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
     (define-key map [remap jump-to-register] #'ebib-jump-to-register)
+    (define-key map "\C-b" #'ebib-history-back)
+    (define-key map "\C-f" #'ebib-history-forward)
     map)
   "Keymap for the Ebib entry buffer.")
 

--- a/ebib.el
+++ b/ebib.el
@@ -1645,7 +1645,43 @@ interactively."
        (ebib--update-entry-buffer)
        (ebib--history-mutate (ebib--get-key-at-point))))
     (default
-      (beep))))
+     (beep))))
+
+(defun ebib-history-back ()
+  "Jump to the last visited entry.
+Repeated invocations of this function and `ebib-history-forward'
+move back and forward in history without changing it. After this,
+moving somewhere else copies the sequence of moves through
+history into the history record, so that they can still be
+accessed."
+  (interactive)
+  (if-let* ((new-head (1+ (ebib--history-get-head)))
+	    (goto (ebib--history-get new-head))
+	    (goto-db (ebib--find-db-for-key goto ebib--cur-db)))
+      (progn
+	(ebib-switch-to-database goto-db)
+	(ebib--goto-entry-in-index goto)
+	(ebib--update-entry-buffer)
+	(ebib--history-set-head new-head))
+    (error "[Ebib] Nowhere to go back to!")))
+
+(defun ebib-history-forward ()
+  "Jump to the entry visited before the current one in the history.
+Repeated invocations of this function and `ebib-history-back'
+move forward and back in history without changing it. After this,
+moving somewhere else copies the sequence of moves through
+history into the history record, so that they can still be
+accessed."
+  (interactive)
+  (if-let ((new-head (1- (ebib--history-get-head)))
+	   (goto (ebib--history-get new-head))
+	   (goto-db (ebib--find-db-for-key goto ebib--cur-db)))
+      (progn
+	(ebib-switch-to-database goto-db)
+	(ebib--goto-entry-in-index goto)
+	(ebib--history-mutate goto)
+	(ebib--update-entry-buffer))
+    (error "[Ebib] Nowhere to go forward to!")))
 
 (defun ebib-show-annotation ()
   "Show the contents of the `annote' or `annotation' field in a *Help* window."

--- a/ebib.el
+++ b/ebib.el
@@ -1131,6 +1131,7 @@ keywords before Emacs is killed."
     (define-key map "y" #'ebib-yank-entry)
     (define-key map "z" #'ebib-leave-ebib-windows)
     (define-key map "Z" #'ebib-lower)
+    (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
     map)
   "Keymap for the ebib index buffer.")
 
@@ -3847,6 +3848,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "\C-xb" 'ebib-quit-entry-buffer)
     (define-key map "\C-xk" 'ebib-quit-entry-buffer)
     (define-key map "\C-x\C-s" #'ebib-save-current-database)
+    (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
     map)
   "Keymap for the Ebib entry buffer.")
 

--- a/ebib.el
+++ b/ebib.el
@@ -847,7 +847,8 @@ loaded, switch to it.  If KEY is given, jump to it."
     (setq ebib--needs-update t))
   (when ebib--needs-update
     (setq ebib--needs-update nil)
-    (ebib--update-buffers 'no-refresh)))
+    (ebib--update-buffers 'no-refresh))
+  (ebib--history-mutate (ebib--get-key-at-point)))
 
 (defun ebib--find-and-set-key (key files)
   "Make KEY the current entry.
@@ -1332,7 +1333,8 @@ in the background, use `ebib--load-bibtex-file-internal'."
   (unless file
     (setq file (ebib--ensure-extension (expand-file-name (read-file-name "File to open: ")) (car ebib-bibtex-extensions))))
   (setq ebib--cur-db (ebib--load-bibtex-file-internal file))
-  (ebib--update-buffers))
+  (ebib--update-buffers)
+  (ebib--history-mutate (ebib--get-key-at-point)))
 
 (defun ebib--load-bibtex-file-internal (file)
   "Load BibTeX file FILE.
@@ -1617,7 +1619,12 @@ buffer if Ebib is not occupying the entire frame."
     (entries
      (if (bobp)                         ; If we're on the first entry,
          (beep)                         ; just beep.
-       (forward-line -1)
+       ;; Only update the history if we actually move (so that trying
+       ;; to move to the previous entry at the top of the buffer
+       ;; doesn't fill the history with repeated references to that
+       ;; entry)
+       (when (zerop (forward-line -1))
+	 (ebib--history-mutate (ebib--get-key-at-point)))
        (ebib--update-entry-buffer)))
     (default
       (beep))))
@@ -1635,7 +1642,8 @@ interactively."
            (forward-line -1)
            (if pfx (beep)))
        (ebib-db-set-current-entry-key (ebib--get-key-at-point) ebib--cur-db)
-       (ebib--update-entry-buffer)))
+       (ebib--update-entry-buffer)
+       (ebib--history-mutate (ebib--get-key-at-point))))
     (default
       (beep))))
 
@@ -1928,7 +1936,8 @@ ORDER indicates the sort order and should be either `ascend' or
     (entries
      (with-current-ebib-buffer 'index
        (goto-char (point-min))
-       (ebib--update-entry-buffer)))
+       (ebib--update-entry-buffer)
+       (ebib--history-mutate (ebib--get-key-at-point))))
     (default
       (beep))))
 
@@ -1940,7 +1949,8 @@ ORDER indicates the sort order and should be either `ascend' or
      (with-current-ebib-buffer 'index
        (goto-char (point-max))
        (forward-line -1)
-       (ebib--update-entry-buffer)))
+       (ebib--update-entry-buffer)
+       (ebib--history-mutate (ebib--get-key-at-point))))
     (default
       (beep))))
 
@@ -2421,7 +2431,8 @@ Interactively, prompt for REGISTER with
     (if (not (ebib-db-has-key key db))
 	(error "[Ebib] Could not find entry key `%s'" key)
       (ebib--goto-entry-in-index key)
-      (ebib--update-entry-buffer))))
+      (ebib--update-entry-buffer)
+      (ebib--history-mutate key))))
 
 (defun ebib-jump-to-entry (arg)
   "Jump to an entry.
@@ -2446,13 +2457,15 @@ candidates from the current database."
        (cond
         ((eq db ebib--cur-db)
          (if (ebib--goto-entry-in-index key)
-             (ebib--update-entry-buffer)
+             (progn (ebib--update-entry-buffer)
+		    (ebib--history-mutate key))
            (error "[Ebib] Could not find entry key `%s'" key)))
         (entries
          (ebib-db-set-current-entry-key (ebib--get-key-at-point) ebib--cur-db) ; Save the current entry for the database we're jumping away from.
          (ebib-db-set-current-entry-key key db) ; Set the current entry in the database we're jumping to.
          (setq ebib--cur-db db)
-         (ebib--update-buffers 'no-refresh))
+         (ebib--update-buffers 'no-refresh)
+	 (ebib--history-mutate key))
         (t (error "[Ebib] Could not jump to entry")))))
     (default
       (error "[Ebib] No database opened"))))

--- a/ebib.el
+++ b/ebib.el
@@ -1132,6 +1132,7 @@ keywords before Emacs is killed."
     (define-key map "z" #'ebib-leave-ebib-windows)
     (define-key map "Z" #'ebib-lower)
     (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
+    (define-key map [remap jump-to-register] #'ebib-jump-to-register)
     map)
   "Keymap for the ebib index buffer.")
 
@@ -3849,6 +3850,7 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "\C-xk" 'ebib-quit-entry-buffer)
     (define-key map "\C-x\C-s" #'ebib-save-current-database)
     (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
+    (define-key map [remap jump-to-register] #'ebib-jump-to-register)
     map)
   "Keymap for the Ebib entry buffer.")
 

--- a/ebib.el
+++ b/ebib.el
@@ -1134,6 +1134,8 @@ keywords before Emacs is killed."
     (define-key map "Z" #'ebib-lower)
     (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
     (define-key map [remap jump-to-register] #'ebib-jump-to-register)
+    (define-key map "\C-b" #'ebib-history-back)
+    (define-key map "\C-f" #'ebib-history-forward)
     map)
   "Keymap for the ebib index buffer.")
 

--- a/manual/ebib.text
+++ b/manual/ebib.text
@@ -1083,6 +1083,8 @@ External packages can provide functions which fulfill a simple interface to repl
  - `:create-note` takes a *key* and a *database* object, and returns a cons of `(BUFFER . POINT)` denoting the start of the note.
  - `:open-note` takes a *key* and returns a buffer containing the note, with point at its start.
 
+Example integration may be found in `ebib-citar.el`.
+
 # Managing a reading list #
 
 Ebib offers the ability to manage a reading list as an Org file. In order to make use of this functionality, you must set the option `ebib-reading-list-file` to a file in which the reading list is stored. Once you've specified a file, you can add the current entry to the reading list with [`R a`]{.key}. The mode line of the entry buffer will show `[R]` to indicate that the current entry is on the reading list.

--- a/manual/ebib.text
+++ b/manual/ebib.text
@@ -945,7 +945,7 @@ If `ebib-notes-storage` is set to `multiple-notes-per-files`, Ebib won't create 
 
 Finally, if `ebib-notes-storage` is set to a function, Ebib will use an external package to manage notes, but will display notes and note status using the package.  (See [External Notes Management](#external-notes-management) for more information.)
 
-New notes are created based on a template (`ebib-note-nemplate`). By default, the note is a top-level item with an Org headline consisting of the author(s), year and title of the entry. The entry also has a `:PROPERTIES:` block containing a custom ID for the entry, which consists of the entry key. If `ebib-notes-storage` is set to `multiple-notes-per-fil`, this custom ID is essential, because it is what Ebib uses to find the note. (If you use `one-file-per-note`, the file name is used to identify an entry, even though the custom ID is still included.)
+New notes are created based on a template (`ebib-note-nemplate`). By default, the note is a top-level item with an Org headline consisting of the author(s), year and title of the entry. The entry also has a `:PROPERTIES:` block containing a custom ID for the entry, which consists of the entry key. If `ebib-notes-storage` is set to `multiple-notes-per-file`, this custom ID is essential, because it is what Ebib uses to find the note. (If you use `one-file-per-note`, the file name is used to identify an entry, even though the custom ID is still included.)
 
 The template can of course be customised. Details are discussed below.
 
@@ -1077,7 +1077,7 @@ Note that Ebib also provides an Ebib-friendly command to call `org-capture` dire
 
 ## External Notes Management ## {.unlisted .unnumbered}
 
-External packages can provide functions which fulfill a simple interface to replace Ebib's note management, as `ebib-notes-storage`. These functions must take two arguments, an action and parameters (a list, based on the action). Known actions and their return values are as follows.
+External packages can provide functions which fulfill a simple interface to replace Ebib's note management, as `ebib-notes-storage`. These functions must arguments in the form `(ACTION &rest PARAMETERS)`. Known actions and their return values are as follows.
 
  - `:has-note` takes a *key* and returns a generalized boolean determining if a note exists for the entry.
  - `:create-note` takes a *key* and a *database* object, and returns a cons of `(BUFFER . POINT)` denoting the start of the note.

--- a/manual/ebib.text
+++ b/manual/ebib.text
@@ -943,6 +943,8 @@ The procedure for creating a new note depends on the setting of `ebib-notes-stor
 
 If `ebib-notes-storage` is set to `multiple-notes-per-files`, Ebib won't create a new file when you create a new note. Instead, it will ask you for the file to save the note to and offer the files in `ebib-notes-locations` as candidates. If you don't want to be asked, you can set the option `ebib-notes-default-file`: new notes are then automatically stored to that file. You can subsequently use Org to move notes around or archive them.
 
+Finally, if `ebib-notes-storage` is set to a function, Ebib will use an external package to manage notes, but will display notes and note status using the package.  (See [External Notes Management](#external-notes-management) for more information.)
+
 New notes are created based on a template (`ebib-note-nemplate`). By default, the note is a top-level item with an Org headline consisting of the author(s), year and title of the entry. The entry also has a `:PROPERTIES:` block containing a custom ID for the entry, which consists of the entry key. If `ebib-notes-storage` is set to `multiple-notes-per-fil`, this custom ID is essential, because it is what Ebib uses to find the note. (If you use `one-file-per-note`, the file name is used to identify an entry, even though the custom ID is still included.)
 
 The template can of course be customised. Details are discussed below.
@@ -1073,6 +1075,13 @@ Note that Ebib only searches for a single note for each entry, so if you create 
 
 Note that Ebib also provides an Ebib-friendly command to call `org-capture` directly. This command, `ebib-org-capture` (not bound to any key by default), takes the same arguments as `org-capture` and can be used in the same way. It makes sure that `ebib-notes-create-org-template` can find the current entry and then calls `org-capture`. 
 
+## External Notes Management ## {.unlisted .unnumbered}
+
+External packages can provide functions which fulfill a simple interface to replace Ebib's note management, as `ebib-notes-storage`. These functions must take two arguments, an action and parameters (a list, based on the action). Known actions and their return values are as follows.
+
+ - `:has-note` takes a *key* and returns a generalized boolean determining if a note exists for the entry.
+ - `:create-note` takes a *key* and a *database* object, and returns a cons of `(BUFFER . POINT)` denoting the start of the note.
+ - `:open-note` takes a *key* and returns a buffer containing the note, with point at its start.
 
 # Managing a reading list #
 


### PR DESCRIPTION
I often find myself adding a new bib entry to my file, only to realise that I need to add a supporting entry of some kind first (like a `Collection`, which I can refer to from an `InCollection`). If the two have different principle authors they won't be very close in my index, so its a hassle to move between them.

I think it would be useful to add two features to deal with this and
similar problems:
1. Commands for jumping through the history of which entries one has visited.
2. Commands similar to `point-to-register` and `jump-to-register`, for storing and jumping to an entry's location. Those commands already kind of work for jumping between entries in the index, but because they are based on the location of point, they can't deal with jumping to an entry after changing the sort order, or adding a new entry. My proposed commands are based on jumping to an entry with a  given key (the history commands would work similarly).
   
This PR:
- adds commands for storing the current entry key in a register, and jumping to an entry by register 
- shadows the bindings for `point-to-register` and `jump-to-register` with these commands
- records history of visited entries
- adds commands for moving backward and forward through the history (and documentation in the variable docstrings about what other commands should do to hook into this)
- binds <kbd>C-b</kbd> and <kbd>C-f</kbd> to moving back/forward in history.

<details> 
<summary> A few notes on my history implementation </summary>
My code is slightly modified version of the stack/head system described at https://gist.github.com/CMCDragonkai/d266a3055735545447439f0fa662a0e1 .

In my implementation:
- there is a list for the history (`:history` in `ebib--entry-history`). Elements nearer the front of the list are more recent in history.
- there is a head pointer (`head` in `ebib--entry-history`). This is a number, a 0-based index into the history list, of where we are currently in the history.
- to move back in history:
  - look up the entry before our current position in history (whatever is at `history-list[head+1]`). Error if there is no such entry.
  - goto that entry.
  - increment head
  - Importantly, going back does not mutate the history list.
- to move forward in history:
  - look up the entry after our current position in history (whatever is at `history-list[head-1]`). Error if there is no such entry.
  - goto that entry.
  - decrement head
  - Importantly, going forward does not mutate the history list.
- When doing anything else (jumping to an entry, going to the next/prev/first/last entry etc.) (in order):
  - take everything from the second to the `head`th element inclusive of the history list, reverse what you've got, and prepend that to the list.
  - prepend the entry we are going to to history
  - set head to 0 (we are at the end of history so far)

So for example...

We open a new database, at entry `@a`. This is pushed to the history list, so now `history` = `("a")` and `head` = 0.

We move to next entry `@b`. `history` = `("b" "a")`, `head` is still 0.

next entry again to `@c`, then `@d`, then `@e`. After this, `history` = `("e" "d" "c" "b" "a")`, `head` is still 0. Notice how the history list is reversed compared with our experience (we visited `@a` first, but "a" is last in the list).

We move back in history (<kbd>M-x</kbd><kbd>ebib-history-back</kbd>). The current entry is now `@d`, `head` becomes 1, but the history list is unchanged as `history` = `("e" "d" "c" "b" "a")`.

Move back again. Current entry is `@c`. Now `head` = 2, `history` is still `("e" "d" "c" "b" "a")`.

And back again. Now `head` = 3, current entry is `@b`, `history` is still `("e" "d" "c" "b" "a")`.

(Notice how `(nth head history)` is always the same as the key of the current entry.)

We now jump to entry `@f` with `ebib-jump-to-entry`. head is 3, so everything from the second history to head will be the things at index 1, index 2 and index 3 (head), which is `("d" "c" "b")`. Reverse this list and prepend to the history list: now `history` = `("b" "c" "d" "e" "d" "c" "b" "a")`. Then add the entry we are jumping to: `history` = `("f" "b" "c" "d" "e" "d" "c" "b" "a")`. Finally, set `head` = 0 (once again, notice that we are at entry `@f`, and element of history at index `history` is "f").

To briefly demonstrate why this makes sense: going back through the description I have just given, a list of entries we have actually visited (in the order we visited them) would be: `a b c d e d c b f`. We are now at `f`. If we go back lots of times, our experience ,*should* just go back along that list. And looking at the `history` list, it will: `history` is just that list backwards.

Currently there is only one history list, used for a whole ebib session, across multiple databases. Entries are located with their key and the current db, by `ebib--find-db-for-key`. I did consider building separate lists for different databases but:
- this would have been more work
- personally, I prefer one master list, so to implement separate lists I would really have had to implement both versions, and control which was used with a user option. This would be fine in terms of user experience, but it would be a *lot* more work, and (since nobody has built this before anyway) I feel there probably isn't the demand for it to be worth it.

Currently, history persists between ebib sessions, so if I open database A, do some stuff, then quit ebib and later open B, my history from A will still be lying around. I'm not sure if this is a problem---it doesn't really effect the experience too much (and I for one mostly use a single huge database anyway), but I can see why some might not like it. What do you think?
</details>