### PR TITLE
Add missing verb to manual

### DIFF
--- a/docs/ebib-manual.html
+++ b/docs/ebib-manual.html
@@ -51,7 +51,7 @@
     code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
     code span.at { color: #7d9029; } /* Attribute */
     code span.bn { color: #40a070; } /* BaseN */
-    code span.bu { } /* BuiltIn */
+    code span.bu { color: #008000; } /* BuiltIn */
     code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
     code span.ch { color: #4070a0; } /* Char */
     code span.cn { color: #880000; } /* Constant */
@@ -64,7 +64,7 @@
     code span.ex { } /* Extension */
     code span.fl { color: #40a070; } /* Float */
     code span.fu { color: #06287e; } /* Function */
-    code span.im { } /* Import */
+    code span.im { color: #008000; font-weight: bold; } /* Import */
     code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
     code span.kw { color: #007020; font-weight: bold; } /* Keyword */
     code span.op { color: #666666; } /* Operator */
@@ -85,9 +85,6 @@
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Merriweather+Sans&family=Roboto+Slab&display=swap" rel="stylesheet">
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
 </head>
 <body>
 <header id="title-block-header">
@@ -96,134 +93,95 @@
 </header>
 <nav id="TOC" role="doc-toc">
 <ul>
-<li><a href="#installation" id="toc-installation">Installation</a></li>
-<li><a href="#getting-started" id="toc-getting-started">Getting
-Started</a>
+<li><a href="#installation">Installation</a></li>
+<li><a href="#getting-started">Getting Started</a>
 <ul>
-<li><a href="#opening-a-.bib-file" id="toc-opening-a-.bib-file">Opening
-a <code>.bib</code> File</a></li>
-<li><a href="#preloading-.bib-files"
-id="toc-preloading-.bib-files">Preloading <code>.bib</code>
-Files</a></li>
-<li><a href="#starting-a-new-.bib-file"
-id="toc-starting-a-new-.bib-file">Starting a New <code>.bib</code>
+<li><a href="#opening-a-.bib-file">Opening a <code>.bib</code>
 File</a></li>
-<li><a href="#closing-a-database" id="toc-closing-a-database">Closing a
-database</a></li>
-<li><a href="#the-database-view" id="toc-the-database-view">The Database
-View</a></li>
-<li><a href="#navigating-the-database"
-id="toc-navigating-the-database">Navigating the Database</a></li>
-<li><a href="#displaying-and-sorting-the-entries-list"
-id="toc-displaying-and-sorting-the-entries-list">Displaying and Sorting
-the Entries List</a></li>
-<li><a href="#biblatex-vs.-bibtex" id="toc-biblatex-vs.-bibtex">Biblatex
-vs. BibTeX</a></li>
+<li><a href="#preloading-.bib-files">Preloading <code>.bib</code>
+Files</a></li>
+<li><a href="#starting-a-new-.bib-file">Starting a New <code>.bib</code>
+File</a></li>
+<li><a href="#closing-a-database">Closing a database</a></li>
+<li><a href="#the-database-view">The Database View</a></li>
+<li><a href="#navigating-the-database">Navigating the Database</a></li>
+<li><a href="#displaying-and-sorting-the-entries-list">Displaying and
+Sorting the Entries List</a></li>
+<li><a href="#biblatex-vs.-bibtex">Biblatex vs. BibTeX</a></li>
 </ul></li>
-<li><a href="#editing-the-database"
-id="toc-editing-the-database">Editing the Database</a>
+<li><a href="#editing-the-database">Editing the Database</a>
 <ul>
-<li><a href="#adding-and-deleting-entries"
-id="toc-adding-and-deleting-entries">Adding and Deleting
+<li><a href="#adding-and-deleting-entries">Adding and Deleting
 Entries</a></li>
-<li><a href="#marking-entries" id="toc-marking-entries">Marking
-Entries</a></li>
-<li><a href="#editing-field-values"
-id="toc-editing-field-values">Editing Field Values</a></li>
-<li><a href="#string-abbreviations-in-field-values"
-id="toc-string-abbreviations-in-field-values"><code>@String</code>
+<li><a href="#marking-entries">Marking Entries</a></li>
+<li><a href="#editing-field-values">Editing Field Values</a></li>
+<li><a href="#string-abbreviations-in-field-values"><code>@String</code>
 abbreviations in field values</a></li>
-<li><a href="#editing-multiline-values"
-id="toc-editing-multiline-values">Editing Multiline Values</a></li>
-<li><a href="#copy-cut-kill-paste-yank-and-delete"
-id="toc-copy-cut-kill-paste-yank-and-delete">Copy, Cut (Kill), Paste
-(Yank), and Delete</a></li>
-<li><a href="#undefined-fields" id="toc-undefined-fields">Undefined
-Fields</a></li>
-<li><a href="#hidden-fields" id="toc-hidden-fields">Hidden
-Fields</a></li>
-<li><a href="#timestamps" id="toc-timestamps">Timestamps</a></li>
-<li><a href="#saving-a-database" id="toc-saving-a-database">Saving a
-Database</a></li>
-<li><a href="#cross-referencing"
-id="toc-cross-referencing">Cross-referencing</a></li>
-<li><a href="#sorting-the-.bib-file"
-id="toc-sorting-the-.bib-file">Sorting the <code>.bib</code>
+<li><a href="#editing-multiline-values">Editing Multiline
+Values</a></li>
+<li><a href="#copy-cut-kill-paste-yank-and-delete">Copy, Cut (Kill),
+Paste (Yank), and Delete</a></li>
+<li><a href="#undefined-fields">Undefined Fields</a></li>
+<li><a href="#hidden-fields">Hidden Fields</a></li>
+<li><a href="#timestamps">Timestamps</a></li>
+<li><a href="#saving-a-database">Saving a Database</a></li>
+<li><a href="#cross-referencing">Cross-referencing</a></li>
+<li><a href="#sorting-the-.bib-file">Sorting the <code>.bib</code>
 File</a></li>
-<li><a href="#preamble-definition" id="toc-preamble-definition"><span
-class="citation" data-cites="Preamble">@Preamble</span>
-Definition</a></li>
-<li><a href="#string-definitions" id="toc-string-definitions"><span
-class="citation" data-cites="String">@String</span> Definitions</a></li>
-<li><a href="#comments" id="toc-comments"><span class="citation"
+<li><a href="#preamble-definition"><span class="citation"
+data-cites="Preamble">@Preamble</span> Definition</a></li>
+<li><a href="#string-definitions"><span class="citation"
+data-cites="String">@String</span> Definitions</a></li>
+<li><a href="#comments"><span class="citation"
 data-cites="Comments">@Comments</span></a></li>
-<li><a href="#creating-entry-stubs"
-id="toc-creating-entry-stubs">Creating Entry Stubs</a></li>
-<li><a href="#multiline-edit-buffers"
-id="toc-multiline-edit-buffers">Multiline Edit Buffers</a></li>
+<li><a href="#creating-entry-stubs">Creating Entry Stubs</a></li>
+<li><a href="#multiline-edit-buffers">Multiline Edit Buffers</a></li>
 </ul></li>
-<li><a href="#main-and-dependent-databases"
-id="toc-main-and-dependent-databases">Main and Dependent
+<li><a href="#main-and-dependent-databases">Main and Dependent
 Databases</a></li>
-<li><a href="#inserting-citations-into-a-text-buffer"
-id="toc-inserting-citations-into-a-text-buffer">Inserting Citations into
-a Text Buffer</a>
+<li><a href="#inserting-citations-into-a-text-buffer">Inserting
+Citations into a Text Buffer</a>
 <ul>
-<li><a href="#single-citations" id="toc-single-citations">Single
-Citations</a></li>
-<li><a href="#citations-with-multiple-keys"
-id="toc-citations-with-multiple-keys">Citations with multiple
+<li><a href="#single-citations">Single Citations</a></li>
+<li><a href="#citations-with-multiple-keys">Citations with multiple
 keys</a></li>
-<li><a href="#key-bindings" id="toc-key-bindings">Key Bindings</a></li>
-<li><a href="#defining-citation-commands"
-id="toc-defining-citation-commands">Defining Citation Commands</a></li>
-<li><a href="#associating-a-database-with-a-text-buffer"
-id="toc-associating-a-database-with-a-text-buffer">Associating a
+<li><a href="#key-bindings">Key Bindings</a></li>
+<li><a href="#defining-citation-commands">Defining Citation
+Commands</a></li>
+<li><a href="#associating-a-database-with-a-text-buffer">Associating a
 Database with a Text Buffer</a></li>
-<li><a href="#links-and-citations-in-org-buffers"
-id="toc-links-and-citations-in-org-buffers">Links and Citations in Org
-buffers</a></li>
+<li><a href="#links-and-citations-in-org-buffers">Links and Citations in
+Org buffers</a></li>
 </ul></li>
-<li><a href="#searching" id="toc-searching">Searching</a></li>
-<li><a href="#filters" id="toc-filters">Filters</a></li>
-<li><a href="#importing-bibtex-entries"
-id="toc-importing-bibtex-entries">Importing BibTeX entries</a>
+<li><a href="#searching">Searching</a></li>
+<li><a href="#filters">Filters</a></li>
+<li><a href="#importing-bibtex-entries">Importing BibTeX entries</a>
 <ul>
-<li><a href="#merging-.bib-files" id="toc-merging-.bib-files">Merging
-<code>.bib</code> files</a></li>
-<li><a href="#importing-entries-from-a-buffer"
-id="toc-importing-entries-from-a-buffer">Importing entries from a
+<li><a href="#merging-.bib-files">Merging <code>.bib</code>
+files</a></li>
+<li><a href="#importing-entries-from-a-buffer">Importing entries from a
 buffer</a></li>
-<li><a href="#integration-with-the-biblio-package"
-id="toc-integration-with-the-biblio-package">Integration with the Biblio
-package</a></li>
-<li><a href="#multiple-identical-fields"
-id="toc-multiple-identical-fields">Multiple Identical Fields</a></li>
+<li><a href="#integration-with-the-biblio-package">Integration with the
+Biblio package</a></li>
+<li><a href="#multiple-identical-fields">Multiple Identical
+Fields</a></li>
 </ul></li>
-<li><a href="#linking-to-external-resources"
-id="toc-linking-to-external-resources">Linking to external resources</a>
+<li><a href="#linking-to-external-resources">Linking to external
+resources</a>
 <ul>
-<li><a href="#viewing-and-importing-files"
-id="toc-viewing-and-importing-files">Viewing and Importing
+<li><a href="#viewing-and-importing-files">Viewing and Importing
 Files</a></li>
-<li><a href="#calling-a-browser-for-urls-and-dois"
-id="toc-calling-a-browser-for-urls-and-dois">Calling a Browser for URLs
-and DOIs</a></li>
+<li><a href="#calling-a-browser-for-urls-and-dois">Calling a Browser for
+URLs and DOIs</a></li>
 </ul></li>
-<li><a href="#notes-files" id="toc-notes-files">Notes files</a></li>
-<li><a href="#managing-a-reading-list"
-id="toc-managing-a-reading-list">Managing a reading list</a></li>
-<li><a href="#managing-keywords" id="toc-managing-keywords">Managing
-Keywords</a></li>
-<li><a href="#window-management" id="toc-window-management">Window
-Management</a></li>
-<li><a href="#copying-entries-to-the-kill-ring"
-id="toc-copying-entries-to-the-kill-ring">Copying Entries to the Kill
-Ring</a></li>
-<li><a href="#printing-the-database"
-id="toc-printing-the-database">Printing the Database</a></li>
-<li><a href="#customisation"
-id="toc-customisation">Customisation</a></li>
+<li><a href="#notes-files">Notes files</a></li>
+<li><a href="#managing-a-reading-list">Managing a reading list</a></li>
+<li><a href="#managing-keywords">Managing Keywords</a></li>
+<li><a href="#window-management">Window Management</a></li>
+<li><a href="#copying-entries-to-the-kill-ring">Copying Entries to the
+Kill Ring</a></li>
+<li><a href="#printing-the-database">Printing the Database</a></li>
+<li><a href="#customisation">Customisation</a></li>
 </ul>
 </nav>
 <p>Ebib is a program with which you can manage <code>biblatex</code> and
@@ -2392,7 +2350,7 @@ can customise this behaviour.)</p>
 to the end of the relevant notes file. If you prefer, you can also use
 Org mode’s capture system to record new notes. This has the advantage
 that you have more control over the location where a note is stored and
-that you can more than one capture template.</p>
+that you can have more than one capture template.</p>
 <p>Note that with Ebib version 2.30, the functionality for notes files
 has changed and it may be necessary to update your configuration. See <a
 href="#upgrading-from-earlier-ebib-versions">Upgrading from earlier Ebib

--- a/ebib.info
+++ b/ebib.info
@@ -1,4 +1,4 @@
-This is ebib.info, produced by makeinfo version 6.7 from ebib.texi.
+This is ebib.info, produced by makeinfo version 6.8 from ebib.texi.
 
 INFO-DIR-SECTION Emacs
 START-INFO-DIR-ENTRY
@@ -2364,7 +2364,7 @@ When you record a new note, Ebib pops up a buffer and adds the note to
 the end of the relevant notes file.  If you prefer, you can also use Org
 mode’s capture system to record new notes.  This has the advantage that
 you have more control over the location where a note is stored and that
-you can more than one capture template.
+you can have more than one capture template.
 
 Note that with Ebib version 2.30, the functionality for notes files has
 changed and it may be necessary to update your configuration.  See *note
@@ -3235,34 +3235,34 @@ Node: Calling a Browser for URLs and DOIs111440
 Ref: #calling-a-browser-for-urls-and-dois111656
 Node: Notes files113964
 Ref: #notes-files114114
-Node: Configuring files for storing notes115601
-Ref: #configuring-files-for-storing-notes115779
-Node: Hooks118746
-Ref: #hooks118909
-Node: Upgrading from earlier Ebib versions120310
-Ref: #upgrading-from-earlier-ebib-versions120533
-Node: Customising the notes file format121443
-Ref: #customising-the-notes-file-format121671
-Node: Displaying notes125695
-Ref: #displaying-notes125886
-Node: Using org-capture to record notes127235
-Ref: #using-org-capture-to-record-notes127426
-Node: Managing a reading list133436
-Ref: #managing-a-reading-list133598
-Node: Managing Keywords136617
-Ref: #managing-keywords136773
-Node: Using a Canonical Keywords List138380
-Ref: #using-a-canonical-keywords-list138538
-Node: Window Management140696
-Ref: #window-management140861
-Node: Copying Entries to the Kill Ring144020
-Ref: #copying-entries-to-the-kill-ring144219
-Node: Printing the Database146944
-Ref: #printing-the-database147117
-Node: Customisation150586
-Ref: #customisation150702
-Node: Modifying Key Bindings151928
-Ref: #modifying-key-bindings152055
+Node: Configuring files for storing notes115606
+Ref: #configuring-files-for-storing-notes115784
+Node: Hooks118751
+Ref: #hooks118914
+Node: Upgrading from earlier Ebib versions120315
+Ref: #upgrading-from-earlier-ebib-versions120538
+Node: Customising the notes file format121448
+Ref: #customising-the-notes-file-format121676
+Node: Displaying notes125700
+Ref: #displaying-notes125891
+Node: Using org-capture to record notes127240
+Ref: #using-org-capture-to-record-notes127431
+Node: Managing a reading list133441
+Ref: #managing-a-reading-list133603
+Node: Managing Keywords136622
+Ref: #managing-keywords136778
+Node: Using a Canonical Keywords List138385
+Ref: #using-a-canonical-keywords-list138543
+Node: Window Management140701
+Ref: #window-management140866
+Node: Copying Entries to the Kill Ring144025
+Ref: #copying-entries-to-the-kill-ring144224
+Node: Printing the Database146949
+Ref: #printing-the-database147122
+Node: Customisation150591
+Ref: #customisation150707
+Node: Modifying Key Bindings151933
+Ref: #modifying-key-bindings152060
 
 End Tag Table
 

--- a/manual/ebib.text
+++ b/manual/ebib.text
@@ -921,7 +921,7 @@ Ebib supports the `annotation` field (or `annote` field in BibTeX), but if you p
 
 In the entry buffer, the first few lines of the note are shown under a pseudo-field `external note`. This is not an actual field in the `.bib` file, even though it is displayed as such. (You can customise this behaviour.)
 
-When you record a new note, Ebib pops up a buffer and adds the note to the end of the relevant notes file. If you prefer, you can also use Org mode's capture system to record new notes. This has the advantage that you have more control over the location where a note is stored and that you can more than one capture template.
+When you record a new note, Ebib pops up a buffer and adds the note to the end of the relevant notes file. If you prefer, you can also use Org mode's capture system to record new notes. This has the advantage that you have more control over the location where a note is stored and that you can have more than one capture template.
 
 Note that with Ebib version 2.30, the functionality for notes files has changed and it may be necessary to update your configuration. See [Upgrading from earlier Ebib versions](#upgrading-from-earlier-ebib-versions) below for details.
 


### PR DESCRIPTION
I added one word in `ebib.text` but apparently pandoc introduced a lot of changes to `ebib-manual.html`. I use pandoc 2.17.1.1. It may not make sense to pull this commit if the next time the manual is edited the structural changes in the html file are reverted.