### PR TITLE
ebib-preload-bib-files: add a safe-local-variable property

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -75,6 +75,7 @@ This option allows you to specify which `.bib' file(s) Ebib
 should load automatically when it starts up.  Specify one file per
 line.  You can complete a partial filename with `M-TAB`."
   :group 'ebib
+  :safe (lambda (val) (seq-every-p #'stringp val))
   :type '(repeat (file :must-match t)))
 
 (defcustom ebib-local-bibfiles t


### PR DESCRIPTION
I've started using a .bib file to hold data for my CV. When I'm working on the TeX (or bbx, cbx, dbx, cls, etc.) in the CV folder, I the only bib file I want to edit is that one. I never really want to edit it otherwise. So, it's useful if this variable can be set locally (using .dir-locals). To avoid having to confirm that it's safe every time, I've added a sensible test for safety.