### PR TITLE
ebib-preload-bib-files: autoload safety predicate

### DIFF
--- a/ebib-utils.el
+++ b/ebib-utils.el
@@ -69,13 +69,13 @@ This is the entry type assigned to newly created entries."
   :group 'ebib
   :type 'string)
 
+;;;###autoload (put 'ebib-preload-bib-files 'safe-local-variable '(lambda (val) (seq-every-p #'stringp val)))
 (defcustom ebib-preload-bib-files nil
   "List of BibTeX files to load automatically when Ebib starts.
 This option allows you to specify which `.bib' file(s) Ebib
 should load automatically when it starts up.  Specify one file per
 line.  You can complete a partial filename with `M-TAB`."
   :group 'ebib
-  :safe (lambda (val) (seq-every-p #'stringp val))
   :type '(repeat (file :must-match t)))
 
 (defcustom ebib-local-bibfiles t


### PR DESCRIPTION
This is an improvement on #296.

Original commit message:

> This is useful because the variable definition, including the `:safe:' declaration, is only loaded as the package is loaded. If the user sets the variable locally (e.g. in `Local Variables') and then visits that file in a new session before opening ebib for the first time, the safe predicate won't be recognised and the user is prompted for whether to use the new value. Using an autoload is the solution to this suggested in the elisp manual `(elisp) File Local Variables'.