### PR TITLE
ebib-history-forward: fix setting head

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -1682,8 +1682,8 @@ accessed."
       (progn
 	(ebib-switch-to-database goto-db)
 	(ebib--goto-entry-in-index goto)
-	(ebib--history-mutate goto)
-	(ebib--update-entry-buffer))
+	(ebib--update-entry-buffer)
+	(ebib--history-set-head new-head))
     (error "[Ebib] Nowhere to go forward to!")))
 
 (defun ebib-show-annotation ()


### PR DESCRIPTION
Fixes comments in #270.

Sorry about this, small error on my part.