### PR TITLE
Standardise entry jump

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -1135,7 +1135,6 @@ keywords before Emacs is killed."
     (define-key map "z" #'ebib-leave-ebib-windows)
     (define-key map "Z" #'ebib-lower)
     (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
-    (define-key map [remap jump-to-register] #'ebib-jump-to-register)
     (define-key map "\C-b" #'ebib-history-back)
     (define-key map "\C-f" #'ebib-history-forward)
     map)
@@ -2464,12 +2463,9 @@ This is to enable `register-val-jump-to' to dispatch properly."
   (interactive `(,(register-read-with-preview "Entry to register: ")))
   (set-register register `(ebib-entry ,(ebib--get-key-at-point))))
 
-(defun ebib-jump-to-register (register)
-  "Jump to entry with key stored in REGISTER.
-Interactively, prompt for REGISTER with
-`register-read-with-preview'."
-  (interactive `(,(register-read-with-preview "Jump to register: ")))
-  (let* ((key (get-register register))
+(cl-defmethod register-val-jump-to ((val (head ebib-entry)) _arg)
+  "Jump to Ebib entry with key which is the cadr of VAL."
+  (let* ((key (cadr val))
 	 (db (ebib--find-db-for-key key ebib--cur-db)))
     (if (not (ebib-db-has-key key db))
 	(error "[Ebib] Could not find entry key `%s'" key)
@@ -3906,7 +3902,6 @@ hook `ebib-reading-list-remove-item-hook' is run."
     (define-key map "\C-xk" 'ebib-quit-entry-buffer)
     (define-key map "\C-x\C-s" #'ebib-save-current-database)
     (define-key map [remap point-to-register] #'ebib-current-entry-to-register)
-    (define-key map [remap jump-to-register] #'ebib-jump-to-register)
     (define-key map "\C-b" #'ebib-history-back)
     (define-key map "\C-f" #'ebib-history-forward)
     map)

--- a/ebib.el
+++ b/ebib.el
@@ -60,6 +60,7 @@
 (require 'mule-util)
 (require 'button)
 (require 'compat)  ; for `pos-bol', `pos-eol'.
+(require 'register)
 (require 'parsebib)
 (require 'ebib-utils)
 (require 'ebib-db)
@@ -2456,9 +2457,12 @@ buffer and switch to it."
 (defun ebib-current-entry-to-register (register)
   "Store current entry's key as a string in REGISTER.
 Interactively, prompt for REGISTER with
-`register-read-with-preview'."
+`register-read-with-preview'.
+
+The entry is stored as a list (ebib-entry KEY), where KEY is a string.
+This is to enable `register-val-jump-to' to dispatch properly."
   (interactive `(,(register-read-with-preview "Entry to register: ")))
-  (set-register register (ebib--get-key-at-point)))
+  (set-register register `(ebib-entry ,(ebib--get-key-at-point))))
 
 (defun ebib-jump-to-register (register)
   "Jump to entry with key stored in REGISTER.


### PR DESCRIPTION
I realised that emacs has a built in system for allowing extensions and external packages to interoperate with registers and jumping. Using this system is better than defining a command like `ebib-jump-to-register`, because you can still use various other register functions inside ebib.

For example, if I store a window config in a register, then open and use ebib, then want to restore the window config, I can just use `jump-to-register` and select the right register. Except that if ebib shadows the binding for `jump-to-register` with it's own similar command, I have to invoke `jump-to-register` manually. The Emacs Way is instead to define a method for ebib-type jumpable objects which are stored in registers, and let `jump-to-register` despatch on that type. That's what this PR does.