### PR TITLE
Import file hook

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -5327,6 +5327,15 @@ is applied.  If no entry matches, URL is returned unchanged."
         (funcall fn url)
       url)))
 
+(defcustom ebib-import-file-functions nil
+  "Abnormal hook run when importing files.
+The functions in this hook are each called with two arguments:the key of
+the entry and the filepath of the imported file (i.e. the path to which
+it is has been written, not the path it was originally retrieved from).
+The return values of these functions are discarded."
+  :group 'ebib-reading-list
+  :type 'hook)
+
 (defun ebib-import-file (arg)
   "Import a file into the database.
 Ask the user for a file path, rename it and move it to the

--- a/ebib.el
+++ b/ebib.el
@@ -5372,6 +5372,7 @@ non-nil, do not delete the original file."
     (let ((files (ebib-get-field-value "file" key ebib--cur-db 'noerror 'unbraced)))
       (when (or (null files)
                 (not (string-match-p (regexp-quote new-name) files)))
+	(run-hook-with-args 'ebib-import-file-functions key dest-path)
         (ebib-set-field-value "file" (ebib--transform-file-name-for-storing (expand-file-name dest-path)) key ebib--cur-db ebib-filename-separator)
         (ebib--set-modified t ebib--cur-db t (seq-filter (lambda (dependent)
                                                            (ebib-db-has-key key dependent))


### PR DESCRIPTION
I wrote [this package](https://github.com/Hugo-Heagren/clever-cite) recently. It's operation requires that for each PDF in my library, a file local variable be set, holding that file's bib key in my database (it's actually more flexible than that, but this is the simple way I'm using it at the moment). I've set this up with all my existing files.

My ebib workflow is that I add new entries to my database, then I use `ebib-import-file` to add files to them. I want to be able to automate the setting of the file-local variable as part of the import process (similarly to how file names for imported files are automatically generated).

To achieve this, and allow (user-customisable) customisation of the process, I have added an abnormal hook to the import function.

I could then do this, and thus automate the process entirely:

``` elisp
(defun my/ebib-set-file-local-key (key filepath)
  ;; Only accept absolute filepaths, because otherwise it's easy to
  ;; write to the wrong place!
  (unless (file-name-absolute-p filepath)
    (error "Filepath `%s' not absolute" filepath))
  (with-current-buffer (find-file-noselect filepath nil 'rawfile)
    ;; Enable writing
    (read-only-mode 0)
    ;; Setup PDF comment syntax
    (setf comment-start "%"
	  comment-end "")
    ;; Add local variable
    (add-file-local-variable 'clever-cite-cite-key key)
    ;; Write the file
    (save-buffer)
    ;; Die!
    (kill-current-buffer)))

(add-hook 'ebib-import-file-functions 'my/ebib-set-file-local-key)
```

(I don't recommend using this exactly -- has various problems. For one, it only handles PDFs, and I even have *some* files which are not PDF)