### PR TITLE
Add filters for imports from DOIs

### DIFF
--- a/ebib-biblio.el
+++ b/ebib-biblio.el
@@ -67,10 +67,8 @@
 (defgroup ebib-biblio nil "Ebib biblio." :group 'ebib)
 
 (defcustom ebib-biblio-import-filters nil
-  "List of filters for entries imported from DOIs. Each filter is a
-function, which takes one entry (an alist with field names as keys, and
-field contents as values) and returns an entry of the same format, with
-any desired changes."
+  "List of filters for entries imported from DOIs. The filters are
+ultimately handled by `ebib--bib-read-entry', which see."
   :group 'ebib-biblio
   :type '(list function))
 

--- a/ebib-biblio.el
+++ b/ebib-biblio.el
@@ -93,7 +93,7 @@ metadata."
                  (goto-char (point-min))
                  (looking-at bibtex-any-entry-maybe-empty-head)
                  (bibtex-key-in-head))))
-      (ebib-import-entries ebib--cur-db)
+      (ebib-import-entries ebib--cur-db ebib-biblio-import-filters)
       (when key
         (ebib-db-set-current-entry-key key ebib--cur-db))
       (ebib--update-buffers))))

--- a/ebib-biblio.el
+++ b/ebib-biblio.el
@@ -66,6 +66,14 @@
 
 (defgroup ebib-biblio nil "Ebib biblio." :group 'ebib)
 
+(defcustom ebib-biblio-import-filters nil
+  "List of filters for entries imported from DOIs. Each filter is a
+function, which takes one entry (an alist with field names as keys, and
+field contents as values) and returns an entry of the same format, with
+any desired changes."
+  :group 'ebib-biblio
+  :type '(list function))
+
 ;;;###autoload
 (defun ebib-biblio-import-doi (doi)
   "Fetch a BibTeX entry from a remote server by its DOI using `biblio.el'.

--- a/ebib-biblio.el
+++ b/ebib-biblio.el
@@ -64,6 +64,8 @@
 (defvar biblio-bibtex-use-autokey)
 (declare-function biblio--selection-forward-bibtex "ext:biblio-core.el" (forward-to &optional quit))
 
+(defgroup ebib-biblio nil "Ebib biblio." :group 'ebib)
+
 ;;;###autoload
 (defun ebib-biblio-import-doi (doi)
   "Fetch a BibTeX entry from a remote server by its DOI using `biblio.el'.

--- a/ebib.el
+++ b/ebib.el
@@ -1468,7 +1468,7 @@ error and return nil."
                 (ebib-db-set-main main db)
               (ebib--log 'error "Could not find main database `%s'" main-file))))))) ; This returns nil.
 
-(defun ebib--bib-find-bibtex-entries (db timestamp)
+(defun ebib--bib-find-bibtex-entries (db timestamp &optional filters)
   "Find the BibTeX entries in the current buffer.
 The search is started at the beginnig of the buffer.  All entries
 found are stored in DB.  Return value is a three-element list: the
@@ -1478,7 +1478,9 @@ indicating whether a @Preamble was found.
 
 TIMESTAMP indicates whether a timestamp is to be added to each
 entry.  Note that a timestamp is only added if `ebib-use-timestamp'
-is set to t."
+is set to t.
+
+FILTERS is passed straight to `ebib--bib-read-entry'."
   (let ((n-entries 0)
         (n-strings 0)
         (preamble nil)
@@ -1496,7 +1498,7 @@ is set to t."
               ((cl-equalp entry-type "comment")
                (ebib--bib-read-comment db))
               ((stringp entry-type)
-               (when (ebib--bib-read-entry db timestamp)
+               (when (ebib--bib-read-entry db timestamp filters)
                  (setq n-entries (1+ n-entries))
                  (unless (assoc-string entry-type entry-list 'case-fold)
                    (ebib--log 'warning "Line %d: Unknown entry type `%s'." (line-number-at-pos) entry-type))))))

--- a/ebib.el
+++ b/ebib.el
@@ -5381,12 +5381,14 @@ non-nil, do not delete the original file."
 
 ;;; Functions for non-Ebib buffers
 
-(defun ebib-import-entries (&optional db)
+(defun ebib-import-entries (&optional db filters)
   "Search for BibTeX entries in the current buffer.
 The entries are added to DB, which defaults to the current
 database (i.e., the database that was active when Ebib was
 lowered.  Works on the whole buffer, or on the region if it is
-active."
+active.
+
+FILTERS is passed straight to `ebib--bib-find-bibtex-entries'."
   (interactive)
   (ebib--execute-when
     (real-db
@@ -5399,7 +5401,7 @@ active."
                (buffer (current-buffer)))
            (with-temp-buffer
              (insert-buffer-substring buffer)
-             (let ((result (ebib--bib-find-bibtex-entries db t)))
+             (let ((result (ebib--bib-find-bibtex-entries db t filters)))
                (ebib-db-set-modified t db)
                (if-let* ((index (ebib-db-get-buffer db))
                          (window (get-buffer-window index t)))

--- a/ebib.el
+++ b/ebib.el
@@ -1582,13 +1582,17 @@ also depends on `ebib-use-timestamp'.)
 
 After reading, but before storing, the entry is passed through FILTERS,
 a list of filter functions. Each filter is a function, which takes one
-entry and returns an entry, with any desired changes."
+entry and returns an entry, with any desired changes. As a special case,
+a filter returning nil is equivalent to it returning the entry
+unchanged (this makes it easier to write filters which only apply in
+some cases -- where they don't apply, just return nil, instead of
+juggling the original and altered versions in a conditional)."
   (condition-case err
       (let* ((beg (point)) ; Save the start of the entry in case something goes wrong.
              (raw-entry (parsebib-read-entry))
 	     ;; Each filter is a function which takes a whole entry,
 	     ;; and returns a whole entry.
-	     (entry (seq-reduce (lambda (arg fun) (funcall fun arg)) filters raw-entry))
+	     (entry (seq-reduce (lambda (arg fun) (or (funcall fun arg) arg)) filters raw-entry))
              (entry-key (cdr (assoc-string "=key=" entry))))
         (if (ebib-db-dependent-p db)
             (if (ebib-db-has-key entry-key (ebib-db-get-main db))


### PR DESCRIPTION
I use biblatex, which prefers all date informatoin to be stored in the `date` field. I also like importing entries directly from their DOIs with ebib-biblio. Unfortunately, the servers which handle the backend of the DOI import mechanism serve date information in the `year` and `month` fields (and often split long titles onto multiple lines, include pleonastic abbrevations in the `publisher` field, and an multitude of other sins). This disparity with how I want to store my data is predictable enough that I would be entirely solved by automatically filtering the entries as they are imported. This PR adds support for exactly that.

The user writes their own filter functions (each takes an entry alist, and returns a new entry alist), and adds them to `ebib-biblio-import-filters`. These filters are then run in order on the entry.

Here's an example of such a filter:

``` elisp
(defun my/ebib-cleanup-multilines (entry)
  (mapcar
   (lambda (elt)
     (let ((field (car elt))
	   (value (cdr elt)))
       (unless (member field ebib-multiline-fields)
	 `(,field . ,(replace-regexp-in-string
		      "[[:space:]]*\n[[:space:]]*" " " value)))))
   entry))

(setq ebib-biblio-import-filters '(my/ebib-cleanup-multilines))

;; Profit
```
(this one is pretty simple -- I had a crack at dates, but it turns out the logic is very complex and it'll take me a while...)
