### PR TITLE
guard `ebib-next-field` against `nil` `field-end`

### DIFF
--- a/ebib.el
+++ b/ebib.el
@@ -4057,12 +4057,19 @@ The prefix argument PFX is used to determine whether the command
 was called interactively."
   (interactive "p")
   (let ((field-end (next-single-property-change (point) 'ebib-field-end)))
-    (if (= (1+ field-end) (point-max))  ; If we would end up at the empty line
-        (if pfx                         ; below the last field, beep.
-            (beep))
-      (goto-char (1+ field-end))        ; Otherwise move point.
-      (while (ebib--line-at-point)      ; And see if we need to adjust.
-        (forward-line 1)))))
+    (cond
+     ;; If we're past the last 'ebib-field-end' change (e.g., after end-of-buffer),
+     ;; do nothing and optionally beep when called interactively.
+     ((null field-end)
+      (when pfx (beep)))
+     ;; If we would end up at the empty line below the last field, just beep.
+     ((= (1+ field-end) (point-max))
+      (when pfx (beep)))
+     ;; Otherwise move point to the next field and adjust if needed.
+     (t
+      (goto-char (1+ field-end))
+      (while (ebib--line-at-point)
+        (forward-line 1))))))
 
 (defun ebib-goto-first-field ()
   "Move to the first field."


### PR DESCRIPTION
## Problem

In `ebib-entry-mode`, if point is not on any field, attempting to move to the next field signals an error:

```emacs-lisp
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
  ebib-next-field(1)
  funcall-interactively(ebib-next-field 1)
  command-execute(ebib-next-field)
```

The cause of this behavior is that `next-single-property-change` returns `nil` when there is no next `ebib-field-end` change, and the code immediately does `(1+ field-end)`.

To reproduce:
1. Open an entry buffer.
2. `M-x end-of-buffer`.
3. Press the down arrow (`ebib-next-field`).

## Fix

- Add a `nil` guard in `ebib-next-field`:
  - If `next-single-property-change` returns `nil`, do nothing (and beep when invoked interactively), avoiding the error.
  - Preserve existing behavior of beeping when the move would land on the empty line below the last field.